### PR TITLE
Add Civ-style unit action menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ target
 .vscode/
 
 .codex
+
+.superpowers/

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -1,7 +1,7 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
-use shared::unit_definition::{UnitRegistry, is_within_move_range};
+use shared::unit_definition::{UnitRegistry, is_within_attack_range, is_within_move_range};
 use shared::{
     components::*,
     events::*,
@@ -20,12 +20,10 @@ pub struct LastSubmittedTurn(pub Option<u32>);
 #[derive(Resource, Default)]
 pub struct HoveredHex(Option<HexPosition>);
 
-/// Trakcks the currently selected unit
-/// and other information related to controling game
+/// Tracks the local player id and other permanent identity info.
 #[derive(Resource, Default)]
 pub struct Controller {
     pub player_id: Option<u32>,
-    pub selected_unit: Option<Entity>,
 }
 
 /// Selection / targeting state. Drives the action bar visibility and
@@ -34,14 +32,11 @@ pub struct Controller {
 pub enum UiState {
     #[default]
     Idle,
-    #[allow(dead_code)]
     UnitSelected { unit: Entity },
-    #[allow(dead_code)]
     Targeting { unit: Entity, verb: TargetableVerb },
 }
 
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 pub enum TargetableVerb {
     Move,
     Attack,
@@ -67,31 +62,58 @@ pub fn update_hex_highlights(
     mut tiles: Query<(&HexPosition, &mut MeshMaterial2d<ColorMaterial>), With<HexTile>>,
     hex_materials: Res<HexMaterials>,
     mut hovered: ResMut<HoveredHex>,
-    controller: ResMut<Controller>,
-    units: Query<(&Unit, &HexPosition)>,
+    ui_state: Res<UiState>,
+    units: Query<(&Unit, &HexPosition, &Owner)>,
     registry: Res<UnitRegistry>,
     all_tiles: Query<&HexPosition, With<HexTile>>,
+    players: Query<&Player>,
+    controller: Res<Controller>,
 ) {
     let cursor_hex = get_cursor_hex(&cursor);
     hovered.0 = cursor_hex;
 
-    let valid_moves: Vec<HexPosition> = if let Some(selected_unit) = controller.selected_unit
-        && let Ok((unit, pos)) = units.get(selected_unit)
-        && let Some(def) = registry.get(&unit.type_id)
-    {
-        all_tiles
-            .iter()
-            .filter(|tile_pos| is_within_move_range(pos, tile_pos, def.move_budget))
-            .copied()
-            .collect()
-    } else {
-        Vec::new()
+    // compute the current overlay set based on UiState
+    let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = match *ui_state {
+        UiState::Targeting { unit, verb } => {
+            let Ok((u, pos, _)) = units.get(unit) else { return; };
+            let Some(def) = registry.get(&u.type_id) else { return; };
+            match verb {
+                TargetableVerb::Move => {
+                    let moves = all_tiles
+                        .iter()
+                        .filter(|t| is_within_move_range(pos, t, def.move_budget))
+                        .copied()
+                        .collect();
+                    (moves, Vec::new())
+                }
+                TargetableVerb::Attack => {
+                    // only enemy-occupied hexes within range light up
+                    let local_player = controller.player_id;
+                    let attacks = units
+                        .iter()
+                        .filter_map(|(_, p, owner)| {
+                            let owner_id = players.get(owner.0).ok().map(|pl| pl.player_id);
+                            let is_enemy = owner_id != local_player;
+                            if is_enemy && is_within_attack_range(pos, p, def.attack_range) {
+                                Some(*p)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    (Vec::new(), attacks)
+                }
+            }
+        }
+        _ => (Vec::new(), Vec::new()),
     };
 
     for (pos, mut material) in &mut tiles {
         if cursor_hex == Some(*pos) {
             *material = MeshMaterial2d(hex_materials.hovered.clone());
-        } else if valid_moves.contains(pos) {
+        } else if attack_targets.contains(pos) {
+            *material = MeshMaterial2d(hex_materials.valid_attack.clone());
+        } else if move_targets.contains(pos) {
             *material = MeshMaterial2d(hex_materials.valid_move.clone());
         } else {
             *material = MeshMaterial2d(hex_materials.default.clone());
@@ -99,102 +121,127 @@ pub fn update_hex_highlights(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_left_click(
     mouse: Res<ButtonInput<MouseButton>>,
     cursor: CursorWorld,
+    mut commands: Commands,
     turn_state: Query<&TurnState>,
     last_submitted: Res<LastSubmittedTurn>,
-    mut controller: ResMut<Controller>,
-    units: Query<(Entity, &Owner, &HexPosition), With<Unit>>,
+    controller: Res<Controller>,
+    mut ui_state: ResMut<UiState>,
+    units: Query<(Entity, &Unit, &Owner, &HexPosition)>,
     players: Query<&Player>,
+    registry: Res<UnitRegistry>,
 ) {
     if !mouse.just_pressed(MouseButton::Left) {
         return;
     }
-    //check whether turn is active
-    let Ok(state) = turn_state.single() else {
-        return;
-    };
-    if state.phase != TurnPhase::Accepting {
-        return;
-    }
-    if last_submitted.0.is_some_and(|t| t >= state.turn_number) {
-        return;
-    }
+    let Ok(state) = turn_state.single() else { return; };
+    if state.phase != TurnPhase::Accepting { return; }
+    if last_submitted.0.is_some_and(|t| t >= state.turn_number) { return; }
 
-    let Some(target) = get_cursor_hex(&cursor) else {
-        return;
+    let Some(target) = get_cursor_hex(&cursor) else { return; };
+    let Some(player_id) = controller.player_id else { return; };
+
+    // is the click on one of my owned units?
+    let owned_unit_at = |hex: HexPosition| -> Option<Entity> {
+        for (entity, _unit, owner, pos) in &units {
+            let owner_id = players.get(owner.0).ok().map(|p| p.player_id);
+            if owner_id == Some(player_id) && *pos == hex {
+                return Some(entity);
+            }
+        }
+        None
     };
 
-    let Some(player_id) = controller.player_id else {
-        return;
-    };
-
-    println!("Target {target:?}");
-    println!("Player id {player_id}");
-    // select clicked unit
-    for (unit_entity, owner, pos) in units {
-        let owner_player_id = players.get(owner.0).ok().map(|p| p.player_id);
-        println!("Unit {unit_entity} with owner {owner_player_id:?} at position {pos:?}");
-        if owner_player_id == Some(player_id) && *pos == target {
-            controller.selected_unit = Some(unit_entity);
-            println!("Selected unit {unit_entity}");
-            return;
+    match *ui_state {
+        UiState::Idle => {
+            if let Some(entity) = owned_unit_at(target) {
+                *ui_state = UiState::UnitSelected { unit: entity };
+            }
+        }
+        UiState::UnitSelected { unit: _ } => {
+            if let Some(entity) = owned_unit_at(target) {
+                *ui_state = UiState::UnitSelected { unit: entity };
+            } else {
+                *ui_state = UiState::Idle;
+            }
+        }
+        UiState::Targeting { unit, verb } => {
+            // clicking another owned unit always switches selection
+            if let Some(entity) = owned_unit_at(target) {
+                *ui_state = UiState::UnitSelected { unit: entity };
+                return;
+            }
+            let Ok((_, u, _, pos)) = units.get(unit) else {
+                *ui_state = UiState::Idle;
+                return;
+            };
+            let Some(def) = registry.get(&u.type_id) else {
+                *ui_state = UiState::Idle;
+                return;
+            };
+            match verb {
+                TargetableVerb::Move => {
+                    if is_within_move_range(pos, &target, def.move_budget) {
+                        commands.client_trigger(UnitActionEvent {
+                            unit,
+                            action: UnitAction::Move { target },
+                        });
+                        *ui_state = UiState::Idle;
+                    } else {
+                        // invalid hex → fall back to selection state, bar stays
+                        *ui_state = UiState::UnitSelected { unit };
+                    }
+                }
+                TargetableVerb::Attack => {
+                    // attacker is at `pos`; enemies are units with a different owner_id at `target`
+                    let enemy_here = units.iter().any(|(_, _, owner, p)| {
+                        *p == target
+                            && players.get(owner.0).ok().map(|pl| pl.player_id) != Some(player_id)
+                    });
+                    if is_within_attack_range(pos, &target, def.attack_range) && enemy_here {
+                        commands.client_trigger(UnitActionEvent {
+                            unit,
+                            action: UnitAction::Attack { target },
+                        });
+                        *ui_state = UiState::Idle;
+                    } else {
+                        *ui_state = UiState::UnitSelected { unit };
+                    }
+                }
+            }
         }
     }
-    controller.selected_unit = None;
-    println!("Deselected unit");
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn handle_right_click(
-    mut commands: Commands,
-    mouse: Res<ButtonInput<MouseButton>>,
-    cursor: CursorWorld,
-    turn_state: Query<&TurnState>,
-    last_submitted: Res<LastSubmittedTurn>,
-    mut controller: ResMut<Controller>,
-    units: Query<(&HexPosition, &Unit)>,
-    registry: Res<UnitRegistry>,
+
+pub fn handle_escape_key(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut ui_state: ResMut<UiState>,
 ) {
-    if !mouse.just_pressed(MouseButton::Right) {
+    if !keys.just_pressed(KeyCode::Escape) {
         return;
     }
-    //check whether turn is active
-    let Ok(state) = turn_state.single() else {
-        return;
+    *ui_state = match *ui_state {
+        UiState::Targeting { unit, .. } => UiState::UnitSelected { unit },
+        _ => UiState::Idle,
     };
-    if state.phase != TurnPhase::Accepting {
-        return;
-    }
-    if last_submitted.0.is_some_and(|t| t >= state.turn_number) {
-        return;
-    }
+}
 
-    let Some(target) = get_cursor_hex(&cursor) else {
-        return;
+// drops UiState back to Idle if the unit it references no longer exists
+pub fn prune_stale_selection(
+    mut ui_state: ResMut<UiState>,
+    units: Query<(), With<Unit>>,
+) {
+    let referenced = match *ui_state {
+        UiState::Idle => return,
+        UiState::UnitSelected { unit } => unit,
+        UiState::Targeting { unit, .. } => unit,
     };
-
-    // proceed only if unit is currently selected
-    let Some(unit_entity) = controller.selected_unit else {
-        return;
-    };
-
-    let Ok((unit_pos, unit)) = units.get(unit_entity) else {
-        return;
-    };
-
-    let Some(def) = registry.get(&unit.type_id) else {
-        return;
-    };
-
-    if is_within_move_range(unit_pos, &target, def.move_budget) {
-        // unit_entity is the client-side Entity; replicon remaps to server-side
-        commands.client_trigger(UnitActionEvent {
-            unit: unit_entity,
-            action: UnitAction::Move { target },
-        });
-        controller.selected_unit = None;
+    if units.get(referenced).is_err() {
+        *ui_state = UiState::Idle;
     }
 }
 

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -170,11 +170,11 @@ pub fn handle_right_click(
     };
 
     if is_within_move_range(unit_pos, &target, def.move_budget) {
-        commands.client_trigger(MoveAction {
-            unit_id: unit.id,
-            target,
+        // unit_entity is the client-side Entity; replicon remaps to server-side
+        commands.client_trigger(UnitActionEvent {
+            unit: unit_entity,
+            action: UnitAction::Move { target },
         });
-        //deselect unit
         controller.selected_unit = None;
     }
 }

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -28,6 +28,25 @@ pub struct Controller {
     pub selected_unit: Option<Entity>,
 }
 
+/// Selection / targeting state. Drives the action bar visibility and
+/// the map-highlight overlay. Idle = no unit selected.
+#[derive(Resource, Default)]
+pub enum UiState {
+    #[default]
+    Idle,
+    #[allow(dead_code)]
+    UnitSelected { unit: Entity },
+    #[allow(dead_code)]
+    Targeting { unit: Entity, verb: TargetableVerb },
+}
+
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub enum TargetableVerb {
+    Move,
+    Attack,
+}
+
 #[derive(SystemParam)]
 pub struct CursorWorld<'w, 's> {
     windows: Query<'w, 's, &'static Window>,

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -79,12 +79,13 @@ pub fn update_hex_highlights(
 
     // compute the current overlay set based on UiState
     let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = match *ui_state {
-        UiState::Targeting { unit, verb } => {
+        UiState::Targeting { unit, verb } => 'overlay: {
             let Ok((u, pos, _)) = units.get(unit) else {
-                return;
+                // stale unit ref — fall through with no overlay so the loop repaints to default
+                break 'overlay (Vec::new(), Vec::new());
             };
             let Some(def) = registry.get(&u.type_id) else {
-                return;
+                break 'overlay (Vec::new(), Vec::new());
             };
             match verb {
                 TargetableVerb::Move => {

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -32,8 +32,13 @@ pub struct Controller {
 pub enum UiState {
     #[default]
     Idle,
-    UnitSelected { unit: Entity },
-    Targeting { unit: Entity, verb: TargetableVerb },
+    UnitSelected {
+        unit: Entity,
+    },
+    Targeting {
+        unit: Entity,
+        verb: TargetableVerb,
+    },
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -75,8 +80,12 @@ pub fn update_hex_highlights(
     // compute the current overlay set based on UiState
     let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = match *ui_state {
         UiState::Targeting { unit, verb } => {
-            let Ok((u, pos, _)) = units.get(unit) else { return; };
-            let Some(def) = registry.get(&u.type_id) else { return; };
+            let Ok((u, pos, _)) = units.get(unit) else {
+                return;
+            };
+            let Some(def) = registry.get(&u.type_id) else {
+                return;
+            };
             match verb {
                 TargetableVerb::Move => {
                     let moves = all_tiles
@@ -137,12 +146,22 @@ pub fn handle_left_click(
     if !mouse.just_pressed(MouseButton::Left) {
         return;
     }
-    let Ok(state) = turn_state.single() else { return; };
-    if state.phase != TurnPhase::Accepting { return; }
-    if last_submitted.0.is_some_and(|t| t >= state.turn_number) { return; }
+    let Ok(state) = turn_state.single() else {
+        return;
+    };
+    if state.phase != TurnPhase::Accepting {
+        return;
+    }
+    if last_submitted.0.is_some_and(|t| t >= state.turn_number) {
+        return;
+    }
 
-    let Some(target) = get_cursor_hex(&cursor) else { return; };
-    let Some(player_id) = controller.player_id else { return; };
+    let Some(target) = get_cursor_hex(&cursor) else {
+        return;
+    };
+    let Some(player_id) = controller.player_id else {
+        return;
+    };
 
     // is the click on one of my owned units?
     let owned_unit_at = |hex: HexPosition| -> Option<Entity> {
@@ -216,11 +235,7 @@ pub fn handle_left_click(
     }
 }
 
-
-pub fn handle_escape_key(
-    keys: Res<ButtonInput<KeyCode>>,
-    mut ui_state: ResMut<UiState>,
-) {
+pub fn handle_escape_key(keys: Res<ButtonInput<KeyCode>>, mut ui_state: ResMut<UiState>) {
     if !keys.just_pressed(KeyCode::Escape) {
         return;
     }
@@ -231,10 +246,7 @@ pub fn handle_escape_key(
 }
 
 // drops UiState back to Idle if the unit it references no longer exists
-pub fn prune_stale_selection(
-    mut ui_state: ResMut<UiState>,
-    units: Query<(), With<Unit>>,
-) {
+pub fn prune_stale_selection(mut ui_state: ResMut<UiState>, units: Query<(), With<Unit>>) {
     let referenced = match *ui_state {
         UiState::Idle => return,
         UiState::UnitSelected { unit } => unit,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -64,6 +64,7 @@ fn main() {
                 handle_right_click,
                 reset_submission_on_new_turn,
                 update_turn_ui,
+                update_action_bar,
             ),
         )
         .run();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
         .add_systems(Startup, (setup_camera, connect_to_server, spawn_turn_ui))
         .add_observer(on_your_player)
         .add_observer(finish_turn_clicked)
+        .add_observer(handle_verb_button_click)
         .add_systems(
             Update,
             (
@@ -61,7 +62,8 @@ fn main() {
                 update_unit_positions,
                 update_hex_highlights,
                 handle_left_click,
-                handle_right_click,
+                handle_escape_key,
+                prune_stale_selection,
                 reset_submission_on_new_turn,
                 update_turn_ui,
                 update_action_bar,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
         .init_resource::<LastSubmittedTurn>()
         .init_resource::<HoveredHex>()
         .init_resource::<Controller>()
+        .init_resource::<UiState>()
         .add_systems(Startup, (setup_camera, connect_to_server, spawn_turn_ui))
         .add_observer(on_your_player)
         .add_observer(finish_turn_clicked)

--- a/client/src/ui.rs
+++ b/client/src/ui.rs
@@ -1,11 +1,12 @@
 use bevy::prelude::*;
 use bevy_replicon::prelude::ClientTriggerExt;
 use shared::components::*;
-use shared::events::FinishTurn;
-use shared::unit_definition::UnitVerb;
+use shared::events::{FinishTurn, UnitAction, UnitActionEvent};
+use shared::unit_definition::{UnitRegistry, UnitVerb, available_verbs};
+use shared::units::Unit;
 
 use crate::LocalPlayerColor;
-use crate::input::{Controller, LastSubmittedTurn};
+use crate::input::{LastSubmittedTurn, TargetableVerb, UiState};
 
 #[derive(Component)]
 pub struct TurnUiText;
@@ -103,7 +104,7 @@ pub fn finish_turn_clicked(
     buttons: Query<(), With<FinishTurnButton>>,
     turn_state: Query<&TurnState>,
     mut last_submitted: ResMut<LastSubmittedTurn>,
-    mut controller: ResMut<Controller>,
+    mut ui_state: ResMut<UiState>,
 ) {
     let Ok(state) = turn_state.single() else {
         return;
@@ -111,7 +112,7 @@ pub fn finish_turn_clicked(
     if buttons.contains(click.entity) {
         commands.client_trigger(FinishTurn);
         last_submitted.0 = Some(state.turn_number);
-        controller.selected_unit = None;
+        *ui_state = UiState::Idle;
     }
 }
 
@@ -149,10 +150,6 @@ pub fn update_turn_ui(
 
     **text = message;
 }
-
-use crate::input::UiState;
-use shared::unit_definition::{UnitRegistry, available_verbs};
-use shared::units::Unit;
 
 // reacts to UiState changes: shows/hides bar, sets enabled/greyed buttons
 pub fn update_action_bar(
@@ -201,5 +198,78 @@ fn verb_label(v: UnitVerb) -> &'static str {
         UnitVerb::Fortify => "Fortify",
         UnitVerb::Build => "Build",
         UnitVerb::Skip => "Skip",
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn handle_verb_button_click(
+    click: On<Pointer<Click>>,
+    mut commands: Commands,
+    buttons: Query<&VerbButton>,
+    mut ui_state: ResMut<UiState>,
+    units: Query<&Unit>,
+    registry: Res<UnitRegistry>,
+    turn_state: Query<&TurnState>,
+    last_submitted: Res<LastSubmittedTurn>,
+) {
+    let Ok(VerbButton(verb)) = buttons.get(click.entity) else { return; };
+
+    // gate: only act during Accepting phase and before the player has finished
+    let Ok(state) = turn_state.single() else { return; };
+    if state.phase != TurnPhase::Accepting { return; }
+    if last_submitted.0.is_some_and(|t| t >= state.turn_number) { return; }
+
+    let unit_entity = match *ui_state {
+        UiState::UnitSelected { unit } => unit,
+        UiState::Targeting { unit, .. } => unit,
+        UiState::Idle => return,
+    };
+
+    let Ok(unit) = units.get(unit_entity) else { return; };
+    let Some(def) = registry.get(&unit.type_id) else { return; };
+    if !available_verbs(def).contains(verb) { return; }
+
+    match verb {
+        UnitVerb::Move => {
+            *ui_state = match *ui_state {
+                // re-clicking the targeting verb toggles back to UnitSelected
+                UiState::Targeting { unit, verb: TargetableVerb::Move } => {
+                    UiState::UnitSelected { unit }
+                }
+                _ => UiState::Targeting { unit: unit_entity, verb: TargetableVerb::Move },
+            };
+        }
+        UnitVerb::Attack => {
+            *ui_state = match *ui_state {
+                UiState::Targeting { unit, verb: TargetableVerb::Attack } => {
+                    UiState::UnitSelected { unit }
+                }
+                _ => UiState::Targeting { unit: unit_entity, verb: TargetableVerb::Attack },
+            };
+        }
+        UnitVerb::Fortify => {
+            commands.client_trigger(UnitActionEvent {
+                unit: unit_entity,
+                action: UnitAction::Fortify,
+            });
+            *ui_state = UiState::Idle;
+        }
+        UnitVerb::Skip => {
+            commands.client_trigger(UnitActionEvent {
+                unit: unit_entity,
+                action: UnitAction::Skip,
+            });
+            *ui_state = UiState::Idle;
+        }
+        UnitVerb::Build => {
+            // single-target stub: only one project per unit today (settler→city);
+            // multi-target Build needs a sub-menu — see future-extensions in spec
+            let Some(project) = def.build_targets.first() else { return; };
+            commands.client_trigger(UnitActionEvent {
+                unit: unit_entity,
+                action: UnitAction::Build { project: project.clone() },
+            });
+            *ui_state = UiState::Idle;
+        }
     }
 }

--- a/client/src/ui.rs
+++ b/client/src/ui.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 use bevy_replicon::prelude::ClientTriggerExt;
 use shared::components::*;
 use shared::events::FinishTurn;
+use shared::unit_definition::UnitVerb;
 
 use crate::LocalPlayerColor;
 use crate::input::{Controller, LastSubmittedTurn};
@@ -11,6 +12,12 @@ pub struct TurnUiText;
 
 #[derive(Component)]
 pub struct FinishTurnButton;
+
+#[derive(Component)]
+pub struct ActionBar;
+
+#[derive(Component)]
+pub struct VerbButton(pub UnitVerb);
 
 pub fn spawn_turn_ui(mut commands: Commands) {
     commands.spawn((
@@ -48,6 +55,46 @@ pub fn spawn_turn_ui(mut commands: Commands) {
             BackgroundColor(Color::BLACK),
         ))
         .with_child((Text::new("Finish Turn"),));
+
+    // bottom-left action bar; hidden while UiState == Idle
+    commands
+        .spawn((
+            ActionBar,
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(10.0),
+                left: Val::Px(10.0),
+                display: Display::None,
+                column_gap: Val::Px(6.0),
+                ..default()
+            },
+        ))
+        .with_children(|parent| {
+            for verb in [
+                UnitVerb::Move,
+                UnitVerb::Attack,
+                UnitVerb::Fortify,
+                UnitVerb::Build,
+                UnitVerb::Skip,
+            ] {
+                parent
+                    .spawn((
+                        VerbButton(verb),
+                        Button,
+                        Node {
+                            width: Val::Px(80.0),
+                            height: Val::Px(40.0),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            border: UiRect::all(Val::Px(2.0)),
+                            ..default()
+                        },
+                        BorderColor::all(Color::linear_rgb(1.0, 0.8, 0.2)),
+                        BackgroundColor(Color::BLACK),
+                    ))
+                    .with_child(Text::new(verb_label(verb)));
+            }
+        });
 }
 
 pub fn finish_turn_clicked(
@@ -101,4 +148,58 @@ pub fn update_turn_ui(
     };
 
     **text = message;
+}
+
+use crate::input::UiState;
+use shared::unit_definition::{UnitRegistry, available_verbs};
+use shared::units::Unit;
+
+// reacts to UiState changes: shows/hides bar, sets enabled/greyed buttons
+pub fn update_action_bar(
+    ui_state: Res<UiState>,
+    mut bars: Query<&mut Node, (With<ActionBar>, Without<VerbButton>)>,
+    mut buttons: Query<(&VerbButton, &mut BackgroundColor)>,
+    units: Query<&Unit>,
+    registry: Res<UnitRegistry>,
+) {
+    if !ui_state.is_changed() {
+        return;
+    }
+    let unit_entity = match *ui_state {
+        UiState::Idle => {
+            for mut node in &mut bars {
+                node.display = Display::None;
+            }
+            return;
+        }
+        UiState::UnitSelected { unit } => unit,
+        UiState::Targeting { unit, .. } => unit,
+    };
+
+    for mut node in &mut bars {
+        node.display = Display::Flex;
+    }
+
+    let Ok(unit) = units.get(unit_entity) else { return; };
+    let Some(def) = registry.get(&unit.type_id) else { return; };
+    let available = available_verbs(def);
+
+    for (button, mut bg) in &mut buttons {
+        if available.contains(&button.0) {
+            *bg = BackgroundColor(Color::BLACK);
+        } else {
+            // greyed: visually distinct but click handler will also reject
+            *bg = BackgroundColor(Color::srgb(0.2, 0.2, 0.2));
+        }
+    }
+}
+
+fn verb_label(v: UnitVerb) -> &'static str {
+    match v {
+        UnitVerb::Move => "Move",
+        UnitVerb::Attack => "Attack",
+        UnitVerb::Fortify => "Fortify",
+        UnitVerb::Build => "Build",
+        UnitVerb::Skip => "Skip",
+    }
 }

--- a/client/src/ui.rs
+++ b/client/src/ui.rs
@@ -143,7 +143,10 @@ pub fn update_turn_ui(
             if submitted {
                 format!("Turn {} -- Waiting for other players...", state.turn_number)
             } else {
-                format!("Turn {} -- Click a neighbor hex to move", state.turn_number)
+                format!(
+                    "Turn {} -- Select a unit, then pick an action",
+                    state.turn_number
+                )
             }
         }
     };
@@ -177,8 +180,12 @@ pub fn update_action_bar(
         node.display = Display::Flex;
     }
 
-    let Ok(unit) = units.get(unit_entity) else { return; };
-    let Some(def) = registry.get(&unit.type_id) else { return; };
+    let Ok(unit) = units.get(unit_entity) else {
+        return;
+    };
+    let Some(def) = registry.get(&unit.type_id) else {
+        return;
+    };
     let available = available_verbs(def);
 
     for (button, mut bg) in &mut buttons {
@@ -212,12 +219,20 @@ pub fn handle_verb_button_click(
     turn_state: Query<&TurnState>,
     last_submitted: Res<LastSubmittedTurn>,
 ) {
-    let Ok(VerbButton(verb)) = buttons.get(click.entity) else { return; };
+    let Ok(VerbButton(verb)) = buttons.get(click.entity) else {
+        return;
+    };
 
     // gate: only act during Accepting phase and before the player has finished
-    let Ok(state) = turn_state.single() else { return; };
-    if state.phase != TurnPhase::Accepting { return; }
-    if last_submitted.0.is_some_and(|t| t >= state.turn_number) { return; }
+    let Ok(state) = turn_state.single() else {
+        return;
+    };
+    if state.phase != TurnPhase::Accepting {
+        return;
+    }
+    if last_submitted.0.is_some_and(|t| t >= state.turn_number) {
+        return;
+    }
 
     let unit_entity = match *ui_state {
         UiState::UnitSelected { unit } => unit,
@@ -225,26 +240,40 @@ pub fn handle_verb_button_click(
         UiState::Idle => return,
     };
 
-    let Ok(unit) = units.get(unit_entity) else { return; };
-    let Some(def) = registry.get(&unit.type_id) else { return; };
-    if !available_verbs(def).contains(verb) { return; }
+    let Ok(unit) = units.get(unit_entity) else {
+        return;
+    };
+    let Some(def) = registry.get(&unit.type_id) else {
+        return;
+    };
+    if !available_verbs(def).contains(verb) {
+        return;
+    }
 
     match verb {
         UnitVerb::Move => {
             *ui_state = match *ui_state {
                 // re-clicking the targeting verb toggles back to UnitSelected
-                UiState::Targeting { unit, verb: TargetableVerb::Move } => {
-                    UiState::UnitSelected { unit }
-                }
-                _ => UiState::Targeting { unit: unit_entity, verb: TargetableVerb::Move },
+                UiState::Targeting {
+                    unit,
+                    verb: TargetableVerb::Move,
+                } => UiState::UnitSelected { unit },
+                _ => UiState::Targeting {
+                    unit: unit_entity,
+                    verb: TargetableVerb::Move,
+                },
             };
         }
         UnitVerb::Attack => {
             *ui_state = match *ui_state {
-                UiState::Targeting { unit, verb: TargetableVerb::Attack } => {
-                    UiState::UnitSelected { unit }
-                }
-                _ => UiState::Targeting { unit: unit_entity, verb: TargetableVerb::Attack },
+                UiState::Targeting {
+                    unit,
+                    verb: TargetableVerb::Attack,
+                } => UiState::UnitSelected { unit },
+                _ => UiState::Targeting {
+                    unit: unit_entity,
+                    verb: TargetableVerb::Attack,
+                },
             };
         }
         UnitVerb::Fortify => {
@@ -264,10 +293,14 @@ pub fn handle_verb_button_click(
         UnitVerb::Build => {
             // single-target stub: only one project per unit today (settler→city);
             // multi-target Build needs a sub-menu — see future-extensions in spec
-            let Some(project) = def.build_targets.first() else { return; };
+            let Some(project) = def.build_targets.first() else {
+                return;
+            };
             commands.client_trigger(UnitActionEvent {
                 unit: unit_entity,
-                action: UnitAction::Build { project: project.clone() },
+                action: UnitAction::Build {
+                    project: project.clone(),
+                },
             });
             *ui_state = UiState::Idle;
         }

--- a/client/src/visuals.rs
+++ b/client/src/visuals.rs
@@ -17,7 +17,6 @@ pub struct HexMaterials {
     pub default: Handle<ColorMaterial>,
     pub hovered: Handle<ColorMaterial>,
     pub valid_move: Handle<ColorMaterial>,
-    #[allow(dead_code)]
     pub valid_attack: Handle<ColorMaterial>,
 }
 

--- a/client/src/visuals.rs
+++ b/client/src/visuals.rs
@@ -17,6 +17,8 @@ pub struct HexMaterials {
     pub default: Handle<ColorMaterial>,
     pub hovered: Handle<ColorMaterial>,
     pub valid_move: Handle<ColorMaterial>,
+    #[allow(dead_code)]
+    pub valid_attack: Handle<ColorMaterial>,
 }
 
 pub fn setup_camera(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
@@ -26,6 +28,7 @@ pub fn setup_camera(mut commands: Commands, mut materials: ResMut<Assets<ColorMa
         default: materials.add(Color::srgb(0.15, 0.15, 0.2)),
         hovered: materials.add(Color::srgb(0.3, 0.3, 0.4)),
         valid_move: materials.add(Color::srgb(0.2, 0.4, 0.2)),
+        valid_attack: materials.add(Color::srgb(0.5, 0.15, 0.15)),
     };
     commands.insert_resource(hex_materials);
 }

--- a/docs/superpowers/specs/2026-05-04-unit-action-menu-design.md
+++ b/docs/superpowers/specs/2026-05-04-unit-action-menu-design.md
@@ -1,0 +1,336 @@
+# Unit Action Menu — Design Spec
+
+## Goal
+
+Replace the implicit "right-click hex = move" interaction with a Civilization-style action menu. When the player selects a unit, a bottom-anchored bar shows the unit's available verbs; the player picks a verb and (for targeted verbs) a destination on the map. The picked action is queued on the server and executed at turn end.
+
+This spec covers the **UI, event plumbing, server-side validation, and queued-action storage** for all five verbs defined in `2026-05-01-unit-system-design.md`. Server-side resolution for non-move verbs is **deliberately stubbed** — combat, fortify mechanics, build mechanics, and passive heal are each their own follow-up spec.
+
+This spec also folds in a related cleanup: switching from a server-assigned `Unit.id: u32` identifier on the wire to a replicon-mapped `Entity`. The two changes share the same surface (`MoveAction` is being replaced anyway) and the `Unit.id` / `UnitCounter` machinery exists *only* to give events something stable to reference.
+
+## Architectural Overview
+
+Three layers, each with one responsibility:
+
+| Layer | Where | Responsibility |
+|-------|-------|----------------|
+| Wire  | `shared/src/events.rs` | One client→server event (`UnitActionEvent`) carrying the verb and its arguments. |
+| Server | `server/src/turn.rs` | One observer validates and queues; per-verb resolver systems apply queued markers at turn end. |
+| Client | `client/src/{input,ui}.rs` | Selection/targeting state machine; bottom action bar rendered from that state; map highlights driven by targeting. |
+
+**Locked decisions** (each chosen during brainstorm):
+
+- **Single coherent flow.** Right-click as a move shortcut is removed. Every verb (including Move) goes through the action bar.
+- **Bottom action bar.** A persistent strip anchored bottom-left, mirroring the existing Finish Turn button anchored bottom-right.
+- **Unified `UnitAction` enum on the wire**, registered as one event. One observer on the server matches on the variant.
+- **One action per unit per turn, mutable.** The latest submission wins; submitting a new verb removes the prior queued marker.
+- **Marker-component-per-verb in the ECS.** `MoveTo` (exists), `AttackTarget`, `Fortifying`, `BuildProject`, `Skipping`. Each verb's resolver queries for its own marker.
+- **Validation is per-event-on-arrival**, not batched at turn end. The queue is the source of truth; Finish Turn only triggers resolution, not validation.
+- **Shared verb-availability helper.** `available_verbs(def)` lives in `shared/`; both client (greying out buttons) and server (rejecting submissions) call it.
+- **Silent reject + log on invalid submissions.** No error event back to the client. The client should never submit invalid actions; bad submissions are bugs or malicious clients.
+- **`Entity` on the wire** with replicon's entity-mapping (the same `#[entities]` pattern used by `Owner`). `Unit.id` and `UnitCounter` are removed.
+
+## Data Shapes
+
+### Wire event
+
+Replaces the existing `MoveAction` in `shared/src/events.rs`:
+
+```rust
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum UnitAction {
+    Move    { target: HexPosition },
+    Attack  { target: HexPosition },
+    Fortify,
+    Build   { project: String },
+    Skip,
+}
+
+#[derive(Event, Serialize, Deserialize, Clone, Debug)]
+pub struct UnitActionEvent {
+    // replicon remaps server↔client entity IDs via the same pattern as Owner
+    #[entities] pub unit: Entity,
+    pub action: UnitAction,
+}
+```
+
+The exact replicon API for mapping entities in client events (e.g. `add_mapped_client_event` vs the derive-based form) is pinned during implementation; the conceptual contract is "the server resolves `unit` to its own server-side entity before validation."
+
+### Verb identity (for UI rendering and validation)
+
+In `shared/src/unit_definition.rs`:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum UnitVerb { Move, Attack, Fortify, Build, Skip }
+
+pub fn available_verbs(def: &UnitDefinition) -> Vec<UnitVerb> {
+    let mut v = vec![UnitVerb::Move, UnitVerb::Fortify, UnitVerb::Skip];
+    if def.attack_damage > 0       { v.push(UnitVerb::Attack); }
+    if !def.build_targets.is_empty() { v.push(UnitVerb::Build); }
+    v
+}
+
+impl UnitAction {
+    pub fn verb(&self) -> UnitVerb { /* discriminant mapping */ }
+}
+```
+
+`UnitVerb` is the *kind* (UI button identity, validator key); `UnitAction` is *kind + payload* (wire shape). Both live in `shared/`.
+
+### Server-side marker components
+
+Beside the existing `MoveTo` in `shared/src/units.rs`. Not replicated, not serialized — they're server-internal queued state, written by the action handler and removed by the resolver:
+
+```rust
+#[derive(Component, Debug)] pub struct Fortifying;
+#[derive(Component, Debug)] pub struct Skipping;
+#[derive(Component, Debug)] pub struct AttackTarget { pub pos: HexPosition }
+#[derive(Component, Debug)] pub struct BuildProject { pub name: String }
+```
+
+### Removed
+
+- `Unit.id: u32` field — no longer needed; `Entity` is the wire identity.
+- `UnitCounter` resource and its `next_id()` callsite in player setup.
+
+### Client-side UI state
+
+Replaces the `selected_unit` field on `Controller` (in `client/src/input.rs`). `Controller.player_id` stays — it's permanent identity, not transient UI state.
+
+```rust
+#[derive(Resource, Default)]
+pub enum UiState {
+    #[default]
+    Idle,
+    UnitSelected { unit: Entity },
+    Targeting   { unit: Entity, verb: TargetableVerb },
+}
+
+#[derive(Clone, Copy)]
+pub enum TargetableVerb { Move, Attack }
+```
+
+Only Move and Attack require a hex pick; Fortify, Skip, and Build resolve their argument client-side at button-press time and dispatch immediately.
+
+## Data Flow — One Verb's Lifecycle
+
+Worked example: warrior selects Attack.
+
+1. **Selection.** Player left-clicks the warrior. `handle_left_click` matches on `UiState::Idle`, transitions to `UnitSelected { unit }`. No map highlight yet.
+2. **Bar appears.** A reactive system (`update_action_bar`) detects the `UiState` change, looks up the unit's `UnitDefinition`, calls `available_verbs(def)`, and renders the bar with `[Move, Attack, Fortify, Skip]` enabled and `[Build]` greyed out.
+3. **Verb pick.** Player clicks the Attack button. The button observer transitions `UiState` to `Targeting { unit, verb: Attack }`. `update_hex_highlights` reads the new state and lights enemy-occupied hexes within `attack_range` in red.
+4. **Target pick.** Player clicks a highlighted enemy hex. `handle_left_click` (now branching on `UiState`) dispatches `UnitActionEvent { unit, action: UnitAction::Attack { target } }` and transitions back to `Idle`.
+5. **Server validates.** The `handle_unit_action` observer fires. Common-path: turn phase is `Accepting`, player hasn't submitted Finish Turn, the resolved `Entity` is owned by this client's player, and `available_verbs(def)` contains `Attack`. Verb-specific: target is enemy-occupied within `attack_range`.
+6. **Mark queued.** Server removes any prior marker on the unit (`MoveTo`, `AttackTarget`, `Fortifying`, `BuildProject`, `Skipping` — single-action invariant) and inserts `AttackTarget { pos: target }`.
+7. **Re-pick allowed.** Until Finish Turn, the player can re-select the warrior, pick Move instead, and the marker swaps. Last-write-wins.
+8. **Resolution.** When all players Finish Turn, per-verb resolver systems run. Only `resolve_moves` does real work in this spec; other resolvers log "would resolve attack/fortify/build/skip" and remove their marker. Combat math is the next spec.
+
+### Cancel paths
+
+| From state | Trigger | To state |
+|-----------|---------|---------|
+| `Targeting { unit, verb }` | ESC pressed | `UnitSelected { unit }` |
+| `Targeting { unit, verb }` | Click invalid hex | `UnitSelected { unit }` |
+| `Targeting { unit, verb }` | Re-click same verb on bar | `UnitSelected { unit }` |
+| `UnitSelected { unit }` | ESC pressed | `Idle` |
+| `UnitSelected { unit }` | Click empty hex | `Idle` |
+| `UnitSelected { _ }` or `Targeting { _, _ }` | Click another owned unit | `UnitSelected { new_unit }` |
+
+## Server Handler
+
+The single observer that replaces `handle_move`. Sketch (final code lands during implementation):
+
+```rust
+pub fn handle_unit_action(
+    trigger: On<FromClient<UnitActionEvent>>,
+    mut commands: Commands,
+    player_map: Res<PlayerMap>,
+    units: Query<(&HexPosition, &Owner, &Unit)>,
+    enemy_units: Query<(&HexPosition, &Owner), With<Unit>>,
+    turn_state: Query<&TurnState>,
+    registry: Res<UnitRegistry>,
+) {
+    // common-path validation
+    let Ok(state) = turn_state.single() else { return; };
+    if state.phase != TurnPhase::Accepting { return; }
+
+    let ClientId::Client(client) = trigger.client_id else { return; };
+    let Some(player) = player_map.client_to_player.get(&client) else { return; };
+
+    let entity = trigger.message.unit;
+    let Ok((pos, owner, unit)) = units.get(entity) else { return; };
+    if owner.0 != *player { return; }
+
+    let Some(def) = registry.get(&unit.type_id) else { return; };
+    let verb = trigger.message.action.verb();
+    if !available_verbs(def).contains(&verb) { return; }
+
+    // single-action invariant: clear any prior marker before inserting
+    let mut e = commands.entity(entity);
+    e.remove::<MoveTo>()
+     .remove::<AttackTarget>()
+     .remove::<Fortifying>()
+     .remove::<BuildProject>()
+     .remove::<Skipping>();
+
+    match &trigger.message.action {
+        UnitAction::Move { target } => {
+            if !is_within_move_range(pos, target, def.move_budget) { return; }
+            if !target.in_bounds(GRID_RADIUS) { return; }
+            e.insert(MoveTo { pos: *target });
+        }
+        UnitAction::Attack { target } => {
+            let in_range = (pos.distance(target) as u32) <= def.attack_range
+                        && pos.distance(target) > 0;
+            let enemy_here = enemy_units.iter()
+                .any(|(p, o)| p == target && o.0 != *player);
+            if !in_range || !enemy_here { return; }
+            e.insert(AttackTarget { pos: *target });
+        }
+        UnitAction::Fortify => { e.insert(Fortifying); }
+        UnitAction::Skip    => { e.insert(Skipping);  }
+        UnitAction::Build { project } => {
+            if !def.build_targets.contains(project) { return; }
+            e.insert(BuildProject { name: project.clone() });
+        }
+    }
+}
+```
+
+### Resolver split
+
+The existing `resolve_turn` in `server/src/turn.rs:138` bundles "apply moves + advance turn + reset finished" into one system. It is split into per-verb resolvers plus a turn-advance step. All resolvers run before turn advance, all gated by "all players finished":
+
+| System | Job |
+|-------|-----|
+| `resolve_moves`   | Apply `MoveTo` to `HexPosition`; remove `MoveTo`. (Existing logic, extracted.) |
+| `resolve_attacks` | Stub: log + remove `AttackTarget`. (Replaced by combat-resolution spec.) |
+| `resolve_fortify` | Stub: log + remove `Fortifying`. (Replaced by combat-resolution spec — adds persistent `Fortified` state.) |
+| `resolve_skip`    | Stub: log + remove `Skipping`. (Replaced by passive-heal spec.) |
+| `resolve_builds`  | Stub: log + remove `BuildProject`. (Replaced by city/economy spec.) |
+| `advance_turn`    | Bump turn number, reset `finished_cnt` and per-player turn state. (Existing logic, extracted.) |
+
+Ordering is explicit (system set with `.before(advance_turn)` on the resolvers).
+
+## Client UI & Input
+
+### Bottom action bar
+
+Spawned once at startup beside the Finish Turn button. A parent `Node` containing five child `Button` entities, each with a `VerbButton(UnitVerb)` marker:
+
+```rust
+#[derive(Component)] pub struct ActionBar;
+#[derive(Component)] pub struct VerbButton(pub UnitVerb);
+```
+
+`update_action_bar` reacts to `UiState` changes:
+
+- `Idle` → bar's `Display::None`.
+- `UnitSelected { unit }` or `Targeting { unit, .. }` → look up the unit's `UnitDefinition`, compute `available_verbs(def)`, set each button's `BackgroundColor` (active vs greyed) and disabled state. Highlight the currently-targeting verb.
+
+### Click handlers
+
+`handle_left_click` is rewritten to branch on `UiState`:
+
+| Current state | Click target | Next state | Side effect |
+|---------------|--------------|------------|-------------|
+| `Idle` | Owned unit | `UnitSelected { unit }` | — |
+| `Idle` | anything else | `Idle` | — |
+| `UnitSelected { _ }` | Owned unit | `UnitSelected { new_unit }` | — |
+| `UnitSelected { _ }` | anything else | `Idle` | — |
+| `Targeting { unit, verb }` | Valid hex (move/attack) | `Idle` | dispatch `UnitActionEvent` |
+| `Targeting { unit, _ }` | Invalid hex | `UnitSelected { unit }` | — |
+| `Targeting { _, _ }` | Owned unit | `UnitSelected { new_unit }` | — |
+
+`handle_right_click` is **deleted** — right-click is no longer a move shortcut.
+
+`handle_verb_button_click` (new observer for `Pointer<Click>` on `VerbButton` entities):
+
+| Verb | Behavior |
+|------|----------|
+| Move / Attack | Transition `UiState` to `Targeting { unit, verb }`. Re-click toggles back to `UnitSelected`. |
+| Fortify / Skip | Dispatch `UnitActionEvent` immediately; transition to `Idle`. |
+| Build | Stub: dispatch with `def.build_targets[0]` (only Settler→city today). A picker UI for multi-target Build is a future extension. |
+
+`handle_escape_key` (new): `Targeting` → `UnitSelected`; `UnitSelected` → `Idle`.
+
+### Map highlights
+
+`update_hex_highlights` reads `UiState`:
+
+- `Targeting { unit, verb: Move }` → blue tint on hexes within `move_budget`.
+- `Targeting { unit, verb: Attack }` → red tint on enemy-occupied hexes within `attack_range`.
+- All other states → only cursor-hover highlight; no range overlay.
+
+`HexMaterials` gains a `valid_attack` material (red-tinted). Existing `valid_move` reused.
+
+### Turn submission gating
+
+Same as today: the `last_submitted` resource short-circuits clicks after Finish Turn for the current turn. Applied uniformly in `handle_left_click`, `handle_verb_button_click`, and `handle_escape_key` (so ESC after submitting doesn't drop you out of "I'm done" UX).
+
+## Edge Cases
+
+1. **Unit despawns mid-turn.** Markers are components on the unit and despawn with it. Client-side, a small system validates the entity in `UiState::UnitSelected/Targeting` still exists each frame; if not, falls back to `Idle`.
+2. **Click on owned unit while `Targeting`.** Treated as switching selection: cancel targeting, transition to `UnitSelected { new_unit }`. Bar re-renders with the new unit's verbs.
+3. **Player not yet assigned.** Initial state is `Idle` and clicks no-op until `Controller.player_id` is set by `YourPlayer`.
+4. **Phase ≠ `Accepting`.** Bar hidden regardless of `UiState`. Same gate as today.
+5. **Idempotent re-submit.** Picking the same verb-target combo twice causes the server to remove-and-reinsert the same marker. Harmless.
+
+## Validation Strategy
+
+Per-event-on-arrival; silent reject + log on failure (matches existing `handle_move` style). The client should never submit invalid actions because the bar greys out unavailable verbs, the targeting highlights restrict valid clicks, and `last_submitted` blocks all input after Finish Turn. A bad submission is a bug or a malicious client; logging is sufficient for the prototype.
+
+Validation only confirms "this verb is plausibly executable given the data and current state." For Attack, the eventual combat resolver will need to handle "target moved away" or "target is dead" since turns are simultaneous — that's a combat-resolution concern, not the action menu's.
+
+## Testing
+
+### Unit tests (in `shared/`)
+
+- `available_verbs` — for each unit type in `assets/units/*.ron`, verify the expected set:
+  - warrior, archer, cavalry, knight → `{Move, Attack, Fortify, Skip}`
+  - settler → `{Move, Fortify, Build, Skip}`
+- `UnitAction::verb()` — round-trip each variant.
+- `is_within_attack_range` (new helper, parallel to `is_within_move_range`) — boundary cases: distance 0 = false (same hex), exactly `attack_range` = true, `attack_range + 1` = false.
+
+### Server-side integration tests (extend the pattern in `server/src/turn.rs`)
+
+- Submit each verb for a valid unit type → corresponding marker is inserted.
+- Submit `Attack` for a settler (`attack_damage = 0`) → no marker (rejected).
+- Submit `Build` for a warrior (`build_targets = []`) → no marker (rejected).
+- Submit `Move` then `Attack` for the same unit → only `AttackTarget` remains, `MoveTo` is gone.
+- Submit any verb when phase is `WaitingForPlayers` → no marker.
+- Submit any verb for another player's unit → no marker.
+
+### Client-side
+
+UI logic (state transitions, button enable/disable, targeting highlights) is hard to test without a Bevy test harness. For this spec, manual verification per a checklist in the implementation plan: each cancel path, each verb type, the targeting flow, and the despawn-during-target edge case.
+
+## Modules Touched
+
+| File | Change |
+|------|--------|
+| `shared/src/events.rs` | Replace `MoveAction` with `UnitAction` enum + `UnitActionEvent`. |
+| `shared/src/unit_definition.rs` | Add `UnitVerb`, `available_verbs(def)`, `is_within_attack_range`. |
+| `shared/src/units.rs` | Add `Fortifying`, `Skipping`, `AttackTarget`, `BuildProject`. Remove `Unit.id` and `UnitCounter`. |
+| `shared/src/plugin.rs` | Replace `MoveAction` registration with mapped `UnitActionEvent`. |
+| `server/src/turn.rs` | Replace `handle_move` with `handle_unit_action`; split `resolve_turn` into per-verb resolvers + `advance_turn`. |
+| `server/src/players.rs` | Remove `UnitCounter::next_id()` use at unit spawn. |
+| `client/src/input.rs` | Add `UiState`, refactor `handle_left_click`, delete `handle_right_click`, add ESC handler. |
+| `client/src/ui.rs` | Add `ActionBar`, `VerbButton`, `update_action_bar`, `handle_verb_button_click`. |
+| `client/src/visuals.rs` | Add `valid_attack` material to `HexMaterials`. |
+
+## Out of Scope (separate specs)
+
+- **Combat resolution.** What `resolve_attacks` actually does. Damage math, retaliation, simultaneous-attack ordering, kill-on-zero-HP.
+- **Persistent fortify.** The `Fortified` state that persists across turns and applies the universal defense multiplier.
+- **City/economy.** What `resolve_builds` actually does — project advancement, settler→city outcome, build-target validation against world state.
+- **Passive heal.** What `resolve_skip` actually does on friendly territory.
+- **Build picker UI.** When a unit has multiple `build_targets`, a sub-menu to pick which one. Today there's only one project per unit so we use `build_targets[0]`.
+
+## Future Extensions
+
+- **Keyboard hotkeys for verbs** (M/A/F/B/S). Easy to add once the `VerbButton` -> `UiState` flow exists.
+- **Tooltips on greyed verbs** explaining why they're disabled ("settlers cannot attack").
+- **Build-target sub-menu** as units gain multiple projects.
+- **Auto-action queues** (Civ-VI "Sleep until healed", "Auto-explore") — additional verbs that schedule recurring actions.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,7 +13,7 @@ use bevy_replicon_renet::{
     netcode::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
     renet::ConnectionConfig,
 };
-use shared::{components::*, hex::generate_grid, plugin::SharedPlugin, units::UnitCounter};
+use shared::{components::*, hex::generate_grid, plugin::SharedPlugin};
 
 use players::*;
 use turn::*;
@@ -46,7 +46,6 @@ fn main() {
         .init_resource::<PlayerMap>()
         .init_resource::<ColorCounter>()
         .init_resource::<PlayerCounter>()
-        .init_resource::<UnitCounter>()
         .init_resource::<PendingMoves>()
         .init_resource::<PlayerState>()
         .add_systems(Startup, (start_server, spawn_grid))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         .init_resource::<PendingMoves>()
         .init_resource::<PlayerState>()
         .add_systems(Startup, (start_server, spawn_grid))
-        .add_observer(handle_move)
+        .add_observer(handle_unit_action)
         .add_observer(handle_finish_turn)
         .add_systems(
             Update,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -46,7 +46,6 @@ fn main() {
         .init_resource::<PlayerMap>()
         .init_resource::<ColorCounter>()
         .init_resource::<PlayerCounter>()
-        .init_resource::<PendingMoves>()
         .init_resource::<PlayerState>()
         .add_systems(Startup, (start_server, spawn_grid))
         .add_observer(handle_unit_action)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -57,7 +57,18 @@ fn main() {
                 handle_new_clients,
                 handle_disconnects,
                 update_turn_phase,
-                resolve_turn,
+                // resolution window: gated as a group so all resolvers see
+                // a consistent "turn end" world; advance_turn closes the window.
+                (
+                    resolve_moves,
+                    resolve_attacks,
+                    resolve_fortify,
+                    resolve_skip,
+                    resolve_builds,
+                    advance_turn,
+                )
+                    .chain()
+                    .run_if(turn_is_resolving),
             )
                 .chain(),
         )

--- a/server/src/players.rs
+++ b/server/src/players.rs
@@ -7,7 +7,7 @@ use shared::events::*;
 use shared::unit_definition::UnitRegistry;
 use shared::{components::*, hex::HexPosition, units::*};
 
-use crate::turn::{PendingMoves, PlayerState, PlayerTurnState};
+use crate::turn::{PlayerState, PlayerTurnState};
 
 /// Maps ConnectedClient entity → Player entity.
 #[derive(Resource, Default)]
@@ -112,7 +112,6 @@ pub fn handle_disconnects(
     mut disconnected: RemovedComponents<ConnectedClient>,
     mut player_map: ResMut<PlayerMap>,
     mut commands: Commands,
-    mut pending_moves: ResMut<PendingMoves>,
     mut player_state: ResMut<PlayerState>,
 ) {
     for client_entity in disconnected.read() {
@@ -121,7 +120,6 @@ pub fn handle_disconnects(
             player_state.finished_cnt -= 1;
         }
         if let Some(player_entity) = player_map.client_to_player.remove(&client_entity) {
-            pending_moves.moves.remove(&player_entity);
             commands.entity(player_entity).despawn();
             println!("Player disconnected, despawned {player_entity}");
         }

--- a/server/src/players.rs
+++ b/server/src/players.rs
@@ -46,7 +46,6 @@ pub fn handle_new_clients(
     mut player_map: ResMut<PlayerMap>,
     mut color_counter: ResMut<ColorCounter>,
     mut player_counter: ResMut<PlayerCounter>,
-    mut unit_counter: ResMut<UnitCounter>,
     registry: Res<UnitRegistry>,
     mut player_state: ResMut<PlayerState>,
 ) {
@@ -90,15 +89,11 @@ pub fn handle_new_clients(
             let definition = registry
                 .get(&type_id)
                 .unwrap_or_else(|| panic!("registry has id but no definition for {unit_type}"));
-            let unit_id = unit_counter.next_id();
             let x = rand::thread_rng().gen_range(-2..=2);
             let y = rand::thread_rng().gen_range(-2..=2);
             let unit_entity = commands
                 .spawn((
-                    Unit {
-                        id: unit_id,
-                        type_id,
-                    },
+                    Unit { type_id },
                     HexPosition::new(x, y),
                     Owner(player_entity),
                     ColorIndex(color_index),

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -12,13 +12,6 @@ use shared::{components::*, hex::HexPosition};
 use crate::GRID_RADIUS;
 use crate::players::PlayerMap;
 
-/// Collects submitted moves during the Accepting phase, then drains them all at once to resolve the turn.
-/// Maps player entity → target hex.
-#[derive(Resource, Default)]
-pub struct PendingMoves {
-    pub moves: HashMap<Entity, HexPosition>,
-}
-
 /// Represents whether player is still making moves or has finished his turn
 #[derive(PartialEq, Eq)]
 pub enum PlayerTurnState {
@@ -34,11 +27,7 @@ pub struct PlayerState {
     pub finished_cnt: i32,
 }
 
-pub fn update_turn_phase(
-    players: Query<(), With<Player>>,
-    mut turn_state: Query<&mut TurnState>,
-    mut pending_moves: ResMut<PendingMoves>,
-) {
+pub fn update_turn_phase(players: Query<(), With<Player>>, mut turn_state: Query<&mut TurnState>) {
     let count = players.iter().count();
     let Ok(mut state) = turn_state.single_mut() else {
         return;
@@ -47,7 +36,6 @@ pub fn update_turn_phase(
     if count < 2 {
         if state.phase != TurnPhase::WaitingForPlayers {
             state.phase = TurnPhase::WaitingForPlayers;
-            pending_moves.moves.clear();
             println!("Not enough players ({count}), waiting...");
         }
     } else if state.phase == TurnPhase::WaitingForPlayers {
@@ -275,21 +263,6 @@ mod tests {
     use super::*;
     use crate::players::PlayerMap;
 
-    #[test]
-    fn test_pending_moves_tracking() {
-        let mut pending = PendingMoves::default();
-        let entity = Entity::from_bits(1);
-        let target = HexPosition::new(1, 0);
-
-        assert!(!pending.moves.contains_key(&entity));
-        pending.moves.insert(entity, target);
-        assert!(pending.moves.contains_key(&entity));
-        assert_eq!(pending.moves.len(), 1);
-
-        pending.moves.drain();
-        assert_eq!(pending.moves.len(), 0);
-    }
-
     /// Regression test: a rejected action must NOT clear a previously queued valid marker.
     ///
     /// Scenario: unit already has `MoveTo` queued. Player submits an invalid Attack
@@ -323,7 +296,6 @@ mod tests {
         registry.definitions.insert(warrior_type, warrior_def);
 
         app.insert_resource(registry);
-        app.init_resource::<PendingMoves>();
         app.init_resource::<PlayerState>();
         app.init_resource::<PlayerMap>();
         app.add_observer(handle_unit_action);

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -317,7 +317,6 @@ mod tests {
             let unit_entity = world
                 .spawn((
                     Unit {
-                        id: 0,
                         type_id: UnitTypeId(0),
                     },
                     HexPosition::new(0, 0),

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -184,42 +184,79 @@ pub fn handle_unit_action(
     }
 }
 
-pub fn resolve_turn(
-    players: Query<Entity, With<Player>>,
+// Each resolver removes its own marker so units start fresh next turn.
+// The turn-resolution gate (all players finished) is applied via run_if
+// at registration time in main.rs — keep these bodies pure so tests can
+// run them in isolation.
+
+pub fn resolve_moves(
     mut units: Query<(Entity, &MoveTo, &mut HexPosition), With<MoveTo>>,
     mut commands: Commands,
-    mut turn_state: Query<&mut TurnState>,
-    mut player_state: ResMut<PlayerState>,
 ) {
-    let Ok(state) = turn_state.single() else {
-        return;
-    };
-    if state.phase != TurnPhase::Accepting {
-        return;
-    }
-
-    let player_count = players.iter().count() as i32;
-    if player_count < 2 || player_state.finished_cnt < player_count {
-        return;
-    }
-
-    // Apply all moves simultaneously
     for (entity, move_to, mut pos) in &mut units {
         *pos = move_to.pos;
         commands.entity(entity).remove::<MoveTo>();
     }
+}
 
-    // Advance turn
-    let Ok(mut state) = turn_state.single_mut() else {
-        return;
-    };
+pub fn resolve_attacks(units: Query<(Entity, &AttackTarget)>, mut commands: Commands) {
+    // stub: combat resolution lands in a separate spec
+    for (entity, target) in &units {
+        println!("(stub) attack from {entity:?} on {:?}", target.pos);
+        commands.entity(entity).remove::<AttackTarget>();
+    }
+}
+
+pub fn resolve_fortify(units: Query<Entity, With<Fortifying>>, mut commands: Commands) {
+    // stub: persistent Fortified state added by combat-resolution spec
+    for entity in &units {
+        println!("(stub) fortify {entity:?}");
+        commands.entity(entity).remove::<Fortifying>();
+    }
+}
+
+pub fn resolve_skip(units: Query<Entity, With<Skipping>>, mut commands: Commands) {
+    // stub: passive heal lands in a separate spec
+    for entity in &units {
+        println!("(stub) skip {entity:?}");
+        commands.entity(entity).remove::<Skipping>();
+    }
+}
+
+pub fn resolve_builds(units: Query<(Entity, &BuildProject)>, mut commands: Commands) {
+    // stub: project advancement lands in city/economy spec
+    for (entity, build) in &units {
+        println!("(stub) build {} on {entity:?}", build.name);
+        commands.entity(entity).remove::<BuildProject>();
+    }
+}
+
+pub fn advance_turn(
+    mut turn_state: Query<&mut TurnState>,
+    mut player_state: ResMut<PlayerState>,
+) {
+    let Ok(mut state) = turn_state.single_mut() else { return; };
     state.turn_number += 1;
-    //reset finished players
     player_state.finished_cnt = 0;
     for val in player_state.turn.values_mut() {
         *val = PlayerTurnState::InProgress;
     }
     println!("Turn resolved! Now on turn {}", state.turn_number);
+}
+
+// run condition: the resolution window — phase = Accepting AND every
+// connected player has hit Finish Turn (>= 2 players to start a turn at all)
+pub fn turn_is_resolving(
+    turn_state: Query<&TurnState>,
+    player_state: Res<PlayerState>,
+    players: Query<(), With<Player>>,
+) -> bool {
+    let Ok(state) = turn_state.single() else { return false; };
+    if state.phase != TurnPhase::Accepting {
+        return false;
+    }
+    let count = players.iter().count() as i32;
+    count >= 2 && player_state.finished_cnt >= count
 }
 
 #[cfg(test)]
@@ -362,5 +399,106 @@ mod tests {
         );
 
         let _ = (player_entity,); // suppress unused-variable warning
+    }
+
+    #[test]
+    fn test_resolve_moves_applies_position() {
+        use bevy::prelude::*;
+        use shared::hex::HexPosition;
+        use shared::unit_definition::UnitTypeId;
+        use shared::units::*;
+
+        let mut app = App::new();
+        app.add_systems(Update, resolve_moves);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Unit { type_id: UnitTypeId(0) },
+                HexPosition::new(0, 0),
+                MoveTo { pos: HexPosition::new(2, -1) },
+            ))
+            .id();
+        app.update();
+        assert_eq!(
+            *app.world().get::<HexPosition>(entity).unwrap(),
+            HexPosition::new(2, -1)
+        );
+        assert!(app.world().get::<MoveTo>(entity).is_none());
+    }
+
+    #[test]
+    fn test_resolve_attacks_removes_marker() {
+        use bevy::prelude::*;
+        use shared::hex::HexPosition;
+        use shared::unit_definition::UnitTypeId;
+        use shared::units::*;
+
+        let mut app = App::new();
+        app.add_systems(Update, resolve_attacks);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Unit { type_id: UnitTypeId(0) },
+                HexPosition::new(0, 0),
+                AttackTarget { pos: HexPosition::new(1, 0) },
+            ))
+            .id();
+        app.update();
+        assert!(app.world().get::<AttackTarget>(entity).is_none());
+    }
+
+    #[test]
+    fn test_resolve_fortify_removes_marker() {
+        use bevy::prelude::*;
+        use shared::hex::HexPosition;
+        use shared::unit_definition::UnitTypeId;
+        use shared::units::*;
+
+        let mut app = App::new();
+        app.add_systems(Update, resolve_fortify);
+        let entity = app
+            .world_mut()
+            .spawn((Unit { type_id: UnitTypeId(0) }, HexPosition::new(0, 0), Fortifying))
+            .id();
+        app.update();
+        assert!(app.world().get::<Fortifying>(entity).is_none());
+    }
+
+    #[test]
+    fn test_resolve_skip_removes_marker() {
+        use bevy::prelude::*;
+        use shared::hex::HexPosition;
+        use shared::unit_definition::UnitTypeId;
+        use shared::units::*;
+
+        let mut app = App::new();
+        app.add_systems(Update, resolve_skip);
+        let entity = app
+            .world_mut()
+            .spawn((Unit { type_id: UnitTypeId(0) }, HexPosition::new(0, 0), Skipping))
+            .id();
+        app.update();
+        assert!(app.world().get::<Skipping>(entity).is_none());
+    }
+
+    #[test]
+    fn test_resolve_builds_removes_marker() {
+        use bevy::prelude::*;
+        use shared::hex::HexPosition;
+        use shared::unit_definition::UnitTypeId;
+        use shared::units::*;
+
+        let mut app = App::new();
+        app.add_systems(Update, resolve_builds);
+        let entity = app
+            .world_mut()
+            .spawn((
+                Unit { type_id: UnitTypeId(0) },
+                HexPosition::new(0, 0),
+                BuildProject { name: "city".into() },
+            ))
+            .id();
+        app.update();
+        assert!(app.world().get::<BuildProject>(entity).is_none());
     }
 }

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
-use shared::unit_definition::{UnitRegistry, is_within_move_range};
+use shared::events::*;
+use shared::unit_definition::{
+    UnitRegistry, available_verbs, is_within_attack_range, is_within_move_range,
+};
 use shared::units::*;
-use shared::{components::*, events::*, hex::HexPosition};
+use shared::{components::*, hex::HexPosition};
 
 use crate::GRID_RADIUS;
 use crate::players::PlayerMap;
@@ -74,65 +77,96 @@ pub fn handle_finish_turn(
     println!("Received finish turn from player {client_entity}. Finished cnt {cnt}");
 }
 
-pub fn handle_move(
-    trigger: On<FromClient<MoveAction>>,
+#[allow(clippy::too_many_arguments)]
+pub fn handle_unit_action(
+    trigger: On<FromClient<UnitActionEvent>>,
     mut commands: Commands,
     player_map: Res<PlayerMap>,
-    units: Query<(Entity, &Unit, &HexPosition, &Owner)>,
+    units: Query<(&HexPosition, &Owner, &Unit)>,
+    enemy_units: Query<(&HexPosition, &Owner), With<Unit>>,
     turn_state: Query<&TurnState>,
     registry: Res<UnitRegistry>,
 ) {
-    let Ok(state) = turn_state.single() else {
-        return;
-    };
+    // common-path validation
+    let Ok(state) = turn_state.single() else { return; };
     if state.phase != TurnPhase::Accepting {
         return;
     }
 
     let client_entity = match trigger.client_id {
-        ClientId::Client(entity) => entity,
+        ClientId::Client(e) => e,
         ClientId::Server => return,
     };
-    let unit_id = trigger.message.unit_id;
-    let target = trigger.message.target;
     let Some(player_entity) = player_map.client_to_player.get(&client_entity) else {
         return;
     };
 
-    let Some((unit_entity, unit, unit_pos, unit_owner)) =
-        units.iter().find(|(_, unit, _, _)| unit.id == unit_id)
-    else {
-        return;
-    };
-
-    //make sure player has right to control this unit
-    if unit_owner.0 != *player_entity {
-        return;
-    };
-
-    //validate movement against the unit's move budget
-    let Some(definition) = registry.get(&unit.type_id) else {
-        println!(
-            "Rejected move: unknown unit type {:?} for unit {unit_id}",
-            unit.type_id
-        );
-        return;
-    };
-    if !is_within_move_range(unit_pos, &target, definition.move_budget) {
-        println!(
-            "Rejected move: unit {unit_id} cannot reach {target:?} from {unit_pos:?} (budget {})",
-            definition.move_budget
-        );
-        return;
-    }
-    if !target.in_bounds(GRID_RADIUS) {
-        println!("Rejected move: {target:?} is out of bounds");
+    let entity = trigger.message.unit;
+    let Ok((pos, owner, unit)) = units.get(entity) else { return; };
+    if owner.0 != *player_entity {
         return;
     }
 
-    println!("Accepting valid movement of unit {unit_id} to pos {target:?}");
-    //add the correct component MoveTo. Overwrites previous by default
-    commands.entity(unit_entity).insert(MoveTo { pos: target });
+    let Some(def) = registry.get(&unit.type_id) else {
+        println!("Rejected action: unknown unit type {:?}", unit.type_id);
+        return;
+    };
+    let verb = trigger.message.action.verb();
+    if !available_verbs(def).contains(&verb) {
+        println!("Rejected action: verb {:?} not available for unit type", verb);
+        return;
+    }
+
+    // single-action invariant: clear any prior queued marker before inserting
+    let mut e = commands.entity(entity);
+    e.remove::<MoveTo>()
+        .remove::<AttackTarget>()
+        .remove::<Fortifying>()
+        .remove::<BuildProject>()
+        .remove::<Skipping>();
+
+    match &trigger.message.action {
+        UnitAction::Move { target } => {
+            if !is_within_move_range(pos, target, def.move_budget) {
+                println!("Rejected move: out of range");
+                return;
+            }
+            if !target.in_bounds(GRID_RADIUS) {
+                println!("Rejected move: out of bounds");
+                return;
+            }
+            e.insert(MoveTo { pos: *target });
+        }
+        UnitAction::Attack { target } => {
+            if !is_within_attack_range(pos, target, def.attack_range) {
+                println!("Rejected attack: out of range");
+                return;
+            }
+            let enemy_here = enemy_units
+                .iter()
+                .any(|(p, o)| p == target && o.0 != *player_entity);
+            if !enemy_here {
+                println!("Rejected attack: no enemy at target");
+                return;
+            }
+            e.insert(AttackTarget { pos: *target });
+        }
+        UnitAction::Fortify => {
+            e.insert(Fortifying);
+        }
+        UnitAction::Skip => {
+            e.insert(Skipping);
+        }
+        UnitAction::Build { project } => {
+            if !def.build_targets.contains(project) {
+                println!("Rejected build: project {project:?} not buildable");
+                return;
+            }
+            e.insert(BuildProject {
+                name: project.clone(),
+            });
+        }
+    }
 }
 
 pub fn resolve_turn(

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -231,11 +231,10 @@ pub fn resolve_builds(units: Query<(Entity, &BuildProject)>, mut commands: Comma
     }
 }
 
-pub fn advance_turn(
-    mut turn_state: Query<&mut TurnState>,
-    mut player_state: ResMut<PlayerState>,
-) {
-    let Ok(mut state) = turn_state.single_mut() else { return; };
+pub fn advance_turn(mut turn_state: Query<&mut TurnState>, mut player_state: ResMut<PlayerState>) {
+    let Ok(mut state) = turn_state.single_mut() else {
+        return;
+    };
     state.turn_number += 1;
     player_state.finished_cnt = 0;
     for val in player_state.turn.values_mut() {
@@ -251,7 +250,9 @@ pub fn turn_is_resolving(
     player_state: Res<PlayerState>,
     players: Query<(), With<Player>>,
 ) -> bool {
-    let Ok(state) = turn_state.single() else { return false; };
+    let Ok(state) = turn_state.single() else {
+        return false;
+    };
     if state.phase != TurnPhase::Accepting {
         return false;
     }
@@ -316,7 +317,9 @@ mod tests {
             terrain_cost: HashMap::new(),
         };
         let mut registry = UnitRegistry::default();
-        registry.name_to_id.insert("warrior".to_string(), warrior_type);
+        registry
+            .name_to_id
+            .insert("warrior".to_string(), warrior_type);
         registry.definitions.insert(warrior_type, warrior_def);
 
         app.insert_resource(registry);
@@ -339,7 +342,12 @@ mod tests {
             });
 
             // Owning player entity.
-            let player_entity = world.spawn(Player { player_id: 0, color_index: 0 }).id();
+            let player_entity = world
+                .spawn(Player {
+                    player_id: 0,
+                    color_index: 0,
+                })
+                .id();
 
             // "Client" entity — just a marker entity replicon would have created.
             let client_entity = world.spawn_empty().id();
@@ -413,9 +421,13 @@ mod tests {
         let entity = app
             .world_mut()
             .spawn((
-                Unit { type_id: UnitTypeId(0) },
+                Unit {
+                    type_id: UnitTypeId(0),
+                },
                 HexPosition::new(0, 0),
-                MoveTo { pos: HexPosition::new(2, -1) },
+                MoveTo {
+                    pos: HexPosition::new(2, -1),
+                },
             ))
             .id();
         app.update();
@@ -438,9 +450,13 @@ mod tests {
         let entity = app
             .world_mut()
             .spawn((
-                Unit { type_id: UnitTypeId(0) },
+                Unit {
+                    type_id: UnitTypeId(0),
+                },
                 HexPosition::new(0, 0),
-                AttackTarget { pos: HexPosition::new(1, 0) },
+                AttackTarget {
+                    pos: HexPosition::new(1, 0),
+                },
             ))
             .id();
         app.update();
@@ -458,7 +474,13 @@ mod tests {
         app.add_systems(Update, resolve_fortify);
         let entity = app
             .world_mut()
-            .spawn((Unit { type_id: UnitTypeId(0) }, HexPosition::new(0, 0), Fortifying))
+            .spawn((
+                Unit {
+                    type_id: UnitTypeId(0),
+                },
+                HexPosition::new(0, 0),
+                Fortifying,
+            ))
             .id();
         app.update();
         assert!(app.world().get::<Fortifying>(entity).is_none());
@@ -475,7 +497,13 @@ mod tests {
         app.add_systems(Update, resolve_skip);
         let entity = app
             .world_mut()
-            .spawn((Unit { type_id: UnitTypeId(0) }, HexPosition::new(0, 0), Skipping))
+            .spawn((
+                Unit {
+                    type_id: UnitTypeId(0),
+                },
+                HexPosition::new(0, 0),
+                Skipping,
+            ))
             .id();
         app.update();
         assert!(app.world().get::<Skipping>(entity).is_none());
@@ -493,9 +521,13 @@ mod tests {
         let entity = app
             .world_mut()
             .spawn((
-                Unit { type_id: UnitTypeId(0) },
+                Unit {
+                    type_id: UnitTypeId(0),
+                },
                 HexPosition::new(0, 0),
-                BuildProject { name: "city".into() },
+                BuildProject {
+                    name: "city".into(),
+                },
             ))
             .id();
         app.update();

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -77,6 +77,18 @@ pub fn handle_finish_turn(
     println!("Received finish turn from player {client_entity}. Finished cnt {cnt}");
 }
 
+// replace the unit's queued action marker in one shot — single-action invariant
+fn queue_marker<M: Component>(commands: &mut Commands, entity: Entity, marker: M) {
+    commands
+        .entity(entity)
+        .remove::<MoveTo>()
+        .remove::<AttackTarget>()
+        .remove::<Fortifying>()
+        .remove::<BuildProject>()
+        .remove::<Skipping>()
+        .insert(marker);
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn handle_unit_action(
     trigger: On<FromClient<UnitActionEvent>>,
@@ -88,7 +100,9 @@ pub fn handle_unit_action(
     registry: Res<UnitRegistry>,
 ) {
     // common-path validation
-    let Ok(state) = turn_state.single() else { return; };
+    let Ok(state) = turn_state.single() else {
+        return;
+    };
     if state.phase != TurnPhase::Accepting {
         return;
     }
@@ -102,7 +116,9 @@ pub fn handle_unit_action(
     };
 
     let entity = trigger.message.unit;
-    let Ok((pos, owner, unit)) = units.get(entity) else { return; };
+    let Ok((pos, owner, unit)) = units.get(entity) else {
+        return;
+    };
     if owner.0 != *player_entity {
         return;
     }
@@ -113,17 +129,12 @@ pub fn handle_unit_action(
     };
     let verb = trigger.message.action.verb();
     if !available_verbs(def).contains(&verb) {
-        println!("Rejected action: verb {:?} not available for unit type", verb);
+        println!(
+            "Rejected action: verb {:?} not available for unit type",
+            verb
+        );
         return;
     }
-
-    // single-action invariant: clear any prior queued marker before inserting
-    let mut e = commands.entity(entity);
-    e.remove::<MoveTo>()
-        .remove::<AttackTarget>()
-        .remove::<Fortifying>()
-        .remove::<BuildProject>()
-        .remove::<Skipping>();
 
     match &trigger.message.action {
         UnitAction::Move { target } => {
@@ -135,7 +146,7 @@ pub fn handle_unit_action(
                 println!("Rejected move: out of bounds");
                 return;
             }
-            e.insert(MoveTo { pos: *target });
+            queue_marker(&mut commands, entity, MoveTo { pos: *target });
         }
         UnitAction::Attack { target } => {
             if !is_within_attack_range(pos, target, def.attack_range) {
@@ -149,22 +160,26 @@ pub fn handle_unit_action(
                 println!("Rejected attack: no enemy at target");
                 return;
             }
-            e.insert(AttackTarget { pos: *target });
+            queue_marker(&mut commands, entity, AttackTarget { pos: *target });
         }
         UnitAction::Fortify => {
-            e.insert(Fortifying);
+            queue_marker(&mut commands, entity, Fortifying);
         }
         UnitAction::Skip => {
-            e.insert(Skipping);
+            queue_marker(&mut commands, entity, Skipping);
         }
         UnitAction::Build { project } => {
             if !def.build_targets.contains(project) {
                 println!("Rejected build: project {project:?} not buildable");
                 return;
             }
-            e.insert(BuildProject {
-                name: project.clone(),
-            });
+            queue_marker(
+                &mut commands,
+                entity,
+                BuildProject {
+                    name: project.clone(),
+                },
+            );
         }
     }
 }
@@ -209,7 +224,18 @@ pub fn resolve_turn(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use bevy::app::ScheduleRunnerPlugin;
+    use bevy::state::app::StatesPlugin;
+    use bevy_replicon::prelude::*;
+    use shared::components::*;
+    use shared::events::*;
+    use shared::unit_definition::*;
+    use shared::units::*;
+
     use super::*;
+    use crate::players::PlayerMap;
 
     #[test]
     fn test_pending_moves_tracking() {
@@ -224,5 +250,118 @@ mod tests {
 
         pending.moves.drain();
         assert_eq!(pending.moves.len(), 0);
+    }
+
+    /// Regression test: a rejected action must NOT clear a previously queued valid marker.
+    ///
+    /// Scenario: unit already has `MoveTo` queued. Player submits an invalid Attack
+    /// (no enemy at the target hex). The `MoveTo` must survive unchanged.
+    #[test]
+    fn test_rejected_action_preserves_prior_marker() {
+        // Minimal Bevy app — no SharedPlugin (avoids assets/ file I/O startup).
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins.set(ScheduleRunnerPlugin::run_once()),
+            StatesPlugin,
+            RepliconPlugins,
+        ));
+
+        // Build a warrior-like registry entry directly, without touching the filesystem.
+        let warrior_type = UnitTypeId(0);
+        let warrior_def = UnitDefinition {
+            hp: 10,
+            move_budget: 2,
+            attack_range: 1,
+            attack_damage: 3,
+            gold_upkeep: 1,
+            production_cost: 10,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("warrior".to_string(), warrior_type);
+        registry.definitions.insert(warrior_type, warrior_def);
+
+        app.insert_resource(registry);
+        app.init_resource::<PendingMoves>();
+        app.init_resource::<PlayerState>();
+        app.init_resource::<PlayerMap>();
+        app.add_observer(handle_unit_action);
+
+        // Flush the startup so RepliconPlugins initialises its state.
+        app.update();
+
+        // Spawn the game world: TurnState in Accepting, two players, one owned unit.
+        let (client_entity, player_entity, unit_entity) = {
+            let world = app.world_mut();
+
+            // Turn state in Accepting phase.
+            world.spawn(TurnState {
+                phase: TurnPhase::Accepting,
+                turn_number: 1,
+            });
+
+            // Owning player entity.
+            let player_entity = world.spawn(Player { player_id: 0, color_index: 0 }).id();
+
+            // "Client" entity — just a marker entity replicon would have created.
+            let client_entity = world.spawn_empty().id();
+
+            // Wire the client → player mapping.
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(client_entity, player_entity);
+
+            // Friendly unit at (0, 0) with a MoveTo already queued.
+            let unit_entity = world
+                .spawn((
+                    Unit {
+                        id: 0,
+                        type_id: UnitTypeId(0),
+                    },
+                    HexPosition::new(0, 0),
+                    Owner(player_entity),
+                    MoveTo {
+                        pos: HexPosition::new(1, 0),
+                    },
+                ))
+                .id();
+
+            (client_entity, player_entity, unit_entity)
+        };
+
+        // Sanity: MoveTo is present before the rejected action.
+        assert!(
+            app.world().get::<MoveTo>(unit_entity).is_some(),
+            "precondition: MoveTo should be present before the test"
+        );
+
+        // Trigger an invalid Attack: target hex (3, 3) has no enemy on it.
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(client_entity),
+            message: UnitActionEvent {
+                unit: unit_entity,
+                action: UnitAction::Attack {
+                    target: HexPosition::new(3, 3),
+                },
+            },
+        });
+
+        // Flush deferred commands from the observer.
+        app.world_mut().flush();
+
+        // The prior MoveTo must still be present — the rejected attack must not clear it.
+        assert!(
+            app.world().get::<MoveTo>(unit_entity).is_some(),
+            "MoveTo was wrongly cleared by a rejected Attack action"
+        );
+        // And no AttackTarget should have been inserted.
+        assert!(
+            app.world().get::<AttackTarget>(unit_entity).is_none(),
+            "AttackTarget was wrongly inserted for a rejected Attack"
+        );
+
+        let _ = (player_entity,); // suppress unused-variable warning
     }
 }

--- a/shared/src/events.rs
+++ b/shared/src/events.rs
@@ -1,4 +1,4 @@
-use bevy::ecs::entity::{EntityMapper, MapEntities};
+use bevy::ecs::entity::MapEntities;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -7,8 +7,9 @@ use crate::unit_definition::UnitVerb;
 
 /// Single client-to-server event covering all per-unit verbs.
 /// `unit` is mapped by replicon between client-side and server-side Entity ids.
-#[derive(Event, Serialize, Deserialize, Clone, Debug)]
+#[derive(Event, Serialize, Deserialize, MapEntities, Clone, Debug)]
 pub struct UnitActionEvent {
+    #[entities]
     pub unit: Entity,
     pub action: UnitAction,
 }
@@ -31,13 +32,6 @@ impl UnitAction {
             UnitAction::Build { .. } => UnitVerb::Build,
             UnitAction::Skip => UnitVerb::Skip,
         }
-    }
-}
-
-// required by replicon's add_mapped_client_event for cross-side Entity remap
-impl MapEntities for UnitActionEvent {
-    fn map_entities<M: EntityMapper>(&mut self, mapper: &mut M) {
-        self.unit = mapper.get_mapped(self.unit);
     }
 }
 

--- a/shared/src/events.rs
+++ b/shared/src/events.rs
@@ -1,11 +1,44 @@
+use bevy::ecs::entity::{EntityMapper, MapEntities};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// Client-to-server event: player wants to move unit to target hex.
+use crate::hex::HexPosition;
+use crate::unit_definition::UnitVerb;
+
+/// Single client-to-server event covering all per-unit verbs.
+/// `unit` is mapped by replicon between client-side and server-side Entity ids.
 #[derive(Event, Serialize, Deserialize, Clone, Debug)]
-pub struct MoveAction {
-    pub unit_id: u32,
-    pub target: crate::hex::HexPosition,
+pub struct UnitActionEvent {
+    pub unit: Entity,
+    pub action: UnitAction,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum UnitAction {
+    Move { target: HexPosition },
+    Attack { target: HexPosition },
+    Fortify,
+    Build { project: String },
+    Skip,
+}
+
+impl UnitAction {
+    pub fn verb(&self) -> UnitVerb {
+        match self {
+            UnitAction::Move { .. } => UnitVerb::Move,
+            UnitAction::Attack { .. } => UnitVerb::Attack,
+            UnitAction::Fortify => UnitVerb::Fortify,
+            UnitAction::Build { .. } => UnitVerb::Build,
+            UnitAction::Skip => UnitVerb::Skip,
+        }
+    }
+}
+
+// required by replicon's add_mapped_client_event for cross-side Entity remap
+impl MapEntities for UnitActionEvent {
+    fn map_entities<M: EntityMapper>(&mut self, mapper: &mut M) {
+        self.unit = mapper.get_mapped(self.unit);
+    }
 }
 
 /// Server-to-client event: tells a client which player is theirs.

--- a/shared/src/plugin.rs
+++ b/shared/src/plugin.rs
@@ -19,7 +19,7 @@ impl Plugin for SharedPlugin {
             .replicate::<Owner>()
             .replicate::<ColorIndex>()
             .replicate::<Health>()
-            .add_client_event::<MoveAction>(Channel::Ordered)
+            .add_mapped_client_event::<UnitActionEvent>(Channel::Ordered)
             .add_client_event::<FinishTurn>(Channel::Ordered)
             .add_server_event::<YourPlayer>(Channel::Ordered)
             .add_systems(Startup, load_unit_registry);

--- a/shared/src/unit_definition.rs
+++ b/shared/src/unit_definition.rs
@@ -128,6 +128,15 @@ pub fn is_within_move_range(
     d > 0 && (d as u32) <= move_budget
 }
 
+pub fn is_within_attack_range(
+    from: &crate::hex::HexPosition,
+    to: &crate::hex::HexPosition,
+    attack_range: u32,
+) -> bool {
+    let d = from.distance(to);
+    d > 0 && (d as u32) <= attack_range
+}
+
 /// Startup system that loads `UnitRegistry` from `assets/units/` and inserts it as a resource.
 /// Registered by `SharedPlugin` so both server and client get it for free.
 pub fn load_unit_registry(mut commands: Commands) {
@@ -287,5 +296,25 @@ mod tests {
         assert!(verbs.contains(&UnitVerb::Skip));
         // settler has attack_damage = 0 → Attack must be absent
         assert!(!verbs.contains(&UnitVerb::Attack));
+    }
+
+    #[test]
+    fn test_is_within_attack_range_boundaries() {
+        use crate::hex::HexPosition;
+
+        let from = HexPosition::new(0, 0);
+        let same = HexPosition::new(0, 0);
+        let one  = HexPosition::new(1, 0);
+        let two  = HexPosition::new(2, 0);
+
+        // attack_range 1: only adjacent enemies
+        assert!(!is_within_attack_range(&from, &same, 1)); // same hex never targetable
+        assert!( is_within_attack_range(&from, &one,  1));
+        assert!(!is_within_attack_range(&from, &two,  1));
+
+        // attack_range 2 (archer): up to 2 hexes away
+        assert!( is_within_attack_range(&from, &one,  2));
+        assert!( is_within_attack_range(&from, &two,  2));
+        assert!(!is_within_attack_range(&from, &HexPosition::new(3, 0), 2));
     }
 }

--- a/shared/src/unit_definition.rs
+++ b/shared/src/unit_definition.rs
@@ -147,6 +147,27 @@ pub fn load_unit_registry(mut commands: Commands) {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum UnitVerb {
+    Move,
+    Attack,
+    Fortify,
+    Build,
+    Skip,
+}
+
+// universal verbs available to every unit; capability flags add the rest
+pub fn available_verbs(def: &UnitDefinition) -> Vec<UnitVerb> {
+    let mut v = vec![UnitVerb::Move, UnitVerb::Fortify, UnitVerb::Skip];
+    if def.attack_damage > 0 {
+        v.push(UnitVerb::Attack);
+    }
+    if !def.build_targets.is_empty() {
+        v.push(UnitVerb::Build);
+    }
+    v
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +256,32 @@ mod tests {
         assert!(is_within_move_range(&from, &close, 2)); // distance 2, budget 2 → ok
         assert!(!is_within_move_range(&from, &far, 2)); // distance 5, budget 2 → out
         assert!(!is_within_move_range(&from, &from, 2)); // same hex → out (no-op move)
+    }
+
+    #[test]
+    fn test_available_verbs_for_warrior_class() {
+        let registry = UnitRegistry::load_from_dir(std::path::Path::new("../assets/units"))
+            .expect("should load");
+        let warrior = registry.get(&registry.id_of("warrior").unwrap()).unwrap();
+        let verbs = available_verbs(warrior);
+        assert!(verbs.contains(&UnitVerb::Move));
+        assert!(verbs.contains(&UnitVerb::Attack));
+        assert!(verbs.contains(&UnitVerb::Fortify));
+        assert!(verbs.contains(&UnitVerb::Skip));
+        assert!(!verbs.contains(&UnitVerb::Build));
+    }
+
+    #[test]
+    fn test_available_verbs_for_settler() {
+        let registry = UnitRegistry::load_from_dir(std::path::Path::new("../assets/units"))
+            .expect("should load");
+        let settler = registry.get(&registry.id_of("settler").unwrap()).unwrap();
+        let verbs = available_verbs(settler);
+        assert!(verbs.contains(&UnitVerb::Move));
+        assert!(verbs.contains(&UnitVerb::Build));
+        assert!(verbs.contains(&UnitVerb::Fortify));
+        assert!(verbs.contains(&UnitVerb::Skip));
+        // settler has attack_damage = 0 → Attack must be absent
+        assert!(!verbs.contains(&UnitVerb::Attack));
     }
 }

--- a/shared/src/unit_definition.rs
+++ b/shared/src/unit_definition.rs
@@ -128,6 +128,7 @@ pub fn is_within_move_range(
     d > 0 && (d as u32) <= move_budget
 }
 
+// intentionally parallel to is_within_move_range — keep semantics in sync
 pub fn is_within_attack_range(
     from: &crate::hex::HexPosition,
     to: &crate::hex::HexPosition,

--- a/shared/src/unit_definition.rs
+++ b/shared/src/unit_definition.rs
@@ -262,13 +262,17 @@ mod tests {
     fn test_available_verbs_for_warrior_class() {
         let registry = UnitRegistry::load_from_dir(std::path::Path::new("../assets/units"))
             .expect("should load");
-        let warrior = registry.get(&registry.id_of("warrior").unwrap()).unwrap();
-        let verbs = available_verbs(warrior);
-        assert!(verbs.contains(&UnitVerb::Move));
-        assert!(verbs.contains(&UnitVerb::Attack));
-        assert!(verbs.contains(&UnitVerb::Fortify));
-        assert!(verbs.contains(&UnitVerb::Skip));
-        assert!(!verbs.contains(&UnitVerb::Build));
+        for name in ["warrior", "archer", "cavalry", "knight"] {
+            let def = registry
+                .get(&registry.id_of(name).expect(name))
+                .expect(name);
+            let verbs = available_verbs(def);
+            assert!(verbs.contains(&UnitVerb::Move),    "{name} should Move");
+            assert!(verbs.contains(&UnitVerb::Attack),  "{name} should Attack");
+            assert!(verbs.contains(&UnitVerb::Fortify), "{name} should Fortify");
+            assert!(verbs.contains(&UnitVerb::Skip),    "{name} should Skip");
+            assert!(!verbs.contains(&UnitVerb::Build),  "{name} cannot Build");
+        }
     }
 
     #[test]

--- a/shared/src/unit_definition.rs
+++ b/shared/src/unit_definition.rs
@@ -277,11 +277,11 @@ mod tests {
                 .get(&registry.id_of(name).expect(name))
                 .expect(name);
             let verbs = available_verbs(def);
-            assert!(verbs.contains(&UnitVerb::Move),    "{name} should Move");
-            assert!(verbs.contains(&UnitVerb::Attack),  "{name} should Attack");
+            assert!(verbs.contains(&UnitVerb::Move), "{name} should Move");
+            assert!(verbs.contains(&UnitVerb::Attack), "{name} should Attack");
             assert!(verbs.contains(&UnitVerb::Fortify), "{name} should Fortify");
-            assert!(verbs.contains(&UnitVerb::Skip),    "{name} should Skip");
-            assert!(!verbs.contains(&UnitVerb::Build),  "{name} cannot Build");
+            assert!(verbs.contains(&UnitVerb::Skip), "{name} should Skip");
+            assert!(!verbs.contains(&UnitVerb::Build), "{name} cannot Build");
         }
     }
 
@@ -305,17 +305,17 @@ mod tests {
 
         let from = HexPosition::new(0, 0);
         let same = HexPosition::new(0, 0);
-        let one  = HexPosition::new(1, 0);
-        let two  = HexPosition::new(2, 0);
+        let one = HexPosition::new(1, 0);
+        let two = HexPosition::new(2, 0);
 
         // attack_range 1: only adjacent enemies
         assert!(!is_within_attack_range(&from, &same, 1)); // same hex never targetable
-        assert!( is_within_attack_range(&from, &one,  1));
-        assert!(!is_within_attack_range(&from, &two,  1));
+        assert!(is_within_attack_range(&from, &one, 1));
+        assert!(!is_within_attack_range(&from, &two, 1));
 
         // attack_range 2 (archer): up to 2 hexes away
-        assert!( is_within_attack_range(&from, &one,  2));
-        assert!( is_within_attack_range(&from, &two,  2));
+        assert!(is_within_attack_range(&from, &one, 2));
+        assert!(is_within_attack_range(&from, &two, 2));
         assert!(!is_within_attack_range(&from, &HexPosition::new(3, 0), 2));
     }
 }

--- a/shared/src/units.rs
+++ b/shared/src/units.rs
@@ -57,6 +57,23 @@ pub struct MoveTo {
     pub pos: HexPosition,
 }
 
+// queued by handle_unit_action; cleared by per-verb resolvers at turn-end
+#[derive(Component, Debug)]
+pub struct Fortifying;
+
+#[derive(Component, Debug)]
+pub struct Skipping;
+
+#[derive(Component, Debug)]
+pub struct AttackTarget {
+    pub pos: HexPosition,
+}
+
+#[derive(Component, Debug)]
+pub struct BuildProject {
+    pub name: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/shared/src/units.rs
+++ b/shared/src/units.rs
@@ -39,7 +39,6 @@ pub struct Unit {
     pub type_id: UnitTypeId,
 }
 
-
 #[derive(Component, Serialize, Deserialize, Debug)]
 pub struct MoveTo {
     pub pos: HexPosition,

--- a/shared/src/units.rs
+++ b/shared/src/units.rs
@@ -58,6 +58,7 @@ pub struct MoveTo {
 }
 
 // queued by handle_unit_action; cleared by per-verb resolvers at turn-end
+
 #[derive(Component, Debug)]
 pub struct Fortifying;
 

--- a/shared/src/units.rs
+++ b/shared/src/units.rs
@@ -36,21 +36,9 @@ pub struct ColorIndex(pub u8);
 #[derive(Component, Serialize, Deserialize, Debug, Clone, Copy)]
 #[require(Replicated, HexPosition)] //intuitively we want every unit to have an owner but Entity doesn't have default
 pub struct Unit {
-    pub id: u32,
     pub type_id: UnitTypeId,
 }
 
-/// Assigns unique ids to players
-#[derive(Resource, Default)]
-pub struct UnitCounter(u32);
-
-impl UnitCounter {
-    pub fn next_id(&mut self) -> u32 {
-        let res = self.0;
-        self.0 += 1;
-        res
-    }
-}
 
 #[derive(Component, Serialize, Deserialize, Debug)]
 pub struct MoveTo {


### PR DESCRIPTION
## Summary
- Replace the right-click-to-move shortcut with a Civ-style action menu. Selecting a unit shows a bottom-anchored bar of available verbs (Move, Attack, Fortify, Build, Skip); the player picks a verb and (for targeted verbs) a hex on the map. Non-Move verbs are stubbed server-side per the design spec — combat / fortify / build / passive heal each get their own follow-up spec.
- Replace `MoveAction { unit_id: u32 }` with a unified `UnitActionEvent { unit: Entity, action: UnitAction }` event using replicon's entity-mapping. `Unit.id` and the `UnitCounter` resource are removed.
- Split `resolve_turn` into per-verb resolver systems (`resolve_moves` does real work; the four others are stubs that log + clear their marker so units start each turn fresh) gated as a group by a `run_if(turn_is_resolving)` condition.
- Client adds a `UiState` resource (Idle / UnitSelected / Targeting) that drives both the action bar and the map-highlight overlay; new `handle_escape_key` and `prune_stale_selection` cover cancel paths and unit-despawn-mid-turn.

Spec: `docs/superpowers/specs/2026-05-04-unit-action-menu-design.md` (committed in this branch).

## Test plan
- [ ] `cargo test` — 26 tests pass (20 shared + 6 server).
- [ ] `cargo clippy --all-targets -- -D warnings` clean.
- [ ] `cargo fmt --check` clean.
- [ ] Two-client smoke test: \`cargo run -p server\` and two \`cargo run -p client 127.0.0.1:5000\` instances.
  - [ ] Click an owned unit → bar appears with greys (Build greyed for warriors, Attack greyed for settler).
  - [ ] Move → blue hex highlights; click a blue hex → unit moves on next Finish Turn.
  - [ ] Attack → red highlights only on enemy-occupied hexes within range; click a red hex → server logs \`(stub) attack from ...\`.
  - [ ] Fortify / Skip / Build buttons → server logs the corresponding stub line; bar disappears.
  - [ ] ESC while targeting → bar stays, highlights gone. ESC while just selected → bar gone.
  - [ ] Click another owned unit while targeting → switches selection.

## Deferred follow-ups (non-blocking, identified in final review)
- Server integration tests for verb-availability rejection (settler+Attack, warrior+Build), phase gate, ownership gate, Move→Attack swap on success path, and a \`UnitAction::verb()\` round-trip.
- Add the \`last_submitted\` gate to \`handle_escape_key\` per spec compliance (benign in practice today).
- Highlight the active-targeting verb on the bar (currently only enabled vs. greyed).
- Hide the bar on phase changes away from \`Accepting\` (today this self-corrects via \`prune_stale_selection\` in normal disconnect flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)