### PR TITLE
Spawn each starting unit on a distinct tile (#6)

### DIFF
--- a/docs/superpowers/specs/2026-05-09-unique-starting-positions-design.md
+++ b/docs/superpowers/specs/2026-05-09-unique-starting-positions-design.md
@@ -1,0 +1,90 @@
+# Unique Starting Unit Positions — Design Spec
+
+## Goal
+
+Guarantee that every starting unit a player receives at join-time spawns on a distinct hex tile — both within a single player's units and across players. Today (`server/src/players.rs:78–101`) the server picks `q` and `r` independently from `gen_range(-2..=2)` for each unit with no per-tile dedup, so two units can collide.
+
+The combat algorithm being landed on `combat-system-spec` assumes turn-start positions are unique; that property is what makes its rollback chain converge. When two units share a tile at game start, the rollback step keeps sending them back to the same tile, the iteration cap (256) trips, and the server panics with `rollback chain failed to terminate` (issue #6).
+
+The fix lives at the spawn site, not in combat. The combat algorithm stays unchanged.
+
+## Scope
+
+**In scope**
+
+- `handle_new_clients` in `server/src/players.rs` — the only place starting units are created today.
+- A small reusable helper for picking N distinct positions out of the spawn region.
+
+**Out of scope**
+
+- Combat code (the invariant becomes true by construction at the spawn call site).
+- Mid-game unit creation (city production already places into the city tile; not a starting-position problem).
+- Player separation — all players still cluster around the origin, same as today. Per-player anchors and squad layouts are a larger design (see *Alternatives considered*).
+- Map size and spawn-region radius — keep current values; flag the tightness.
+
+## Approach
+
+**Locked decision: per-tile dedup at spawn time, implemented as enumerate → filter → shuffle → take.** For each new player processed in `handle_new_clients`, build the set of tiles already occupied by existing units (and by units chosen earlier in the same frame), enumerate the candidate spawn region, filter out occupied tiles, shuffle the remainder with `rand`, and assign the first `N` tiles to the new player's `N` starting units.
+
+### Why this shape over the alternatives
+
+- **Versus a retry loop** ("pick random; if taken, pick again"). Same random feel, but no retry bound to tune and no pathological behavior near saturation. Failure becomes a cheap `candidates.len() < count` check rather than hitting a counter, and the outcome is uniform over the available tiles.
+- **Versus a deterministic squad layout** (fixed offsets from a per-player anchor). Squad layout solves more (it also separates players), but it requires a *new* prerequisite — choosing player anchors on the map — with its own design questions (anchor-selection algorithm, fairness, configurability). Issue #6 is positional uniqueness; this approach fixes that minimally and doesn't preclude squads layering on top later.
+
+### Frame-local in-flight tracking
+
+`handle_new_clients` is `Update`-scheduled and may match multiple `Added<AuthorizedClient>` entities in a single tick (two players authorize on the same frame). Each iteration uses `Commands::spawn`, which doesn't materialize until `Commands` flushes — so a same-frame second iteration's `Query<&HexPosition, With<Unit>>` would not see the first iteration's just-spawned units.
+
+The fix tracks an `occupied: HashSet<HexPosition>` *outside* the per-client loop, seeded from the existing-units query, and updates it in-line as each unit's position is decided. This makes uniqueness across same-frame joins independent of `Commands` flush ordering.
+
+### Spawn region
+
+Keep the existing axial parallelogram `q ∈ [-2, 2], r ∈ [-2, 2]` (25 tiles) for minimum diff. Capacity check: `max_clients = 8`; starting units will become 3 once `combat-system-spec` lands → up to 24 units. 24-of-25 is barely-fitting. Lift the magic numbers into a `STARTING_AREA_HALF_EXTENT: i32 = 2` constant with a comment noting the tightness and that the region is a parallelogram, not a hex disc; expanding it is then a one-line change when needed. Defer the expansion itself — that's a balance/feel decision, not part of this fix.
+
+### Helper signature
+
+```rust
+fn pick_starting_positions(
+    occupied: &HashSet<HexPosition>,
+    count: usize,
+    rng: &mut impl Rng,
+) -> Vec<HexPosition>
+```
+
+Behavior:
+1. Enumerate the spawn region (`q, r ∈ [-STARTING_AREA_HALF_EXTENT, STARTING_AREA_HALF_EXTENT]`, two nested ranges).
+2. Filter out positions present in `occupied`.
+3. Shuffle the remaining `Vec` in place (e.g. `SliceRandom::shuffle`).
+4. Return the first `count` positions.
+5. Panic if `candidates.len() < count` with a clear message naming the requested count and available count.
+
+`&mut impl Rng` lets production pass `&mut rand::thread_rng()` and tests pass a seeded `StdRng` for determinism.
+
+### Call-site changes in `handle_new_clients`
+
+- New parameter: `existing_units: Query<&HexPosition, With<Unit>>`.
+- Before the per-client loop: `let mut occupied: HashSet<HexPosition> = existing_units.iter().copied().collect(); let mut rng = rand::thread_rng();`
+- Inside the per-client loop, *before* the unit-spawning inner loop: `let positions = pick_starting_positions(&occupied, starting_units.len(), &mut rng);`
+- Replace the per-unit `gen_range` calls with `positions[i]`. After spawning each unit, `occupied.insert(positions[i]);`.
+
+The existing `rand::thread_rng().gen_range(-2..=2)` calls go away.
+
+## Error handling
+
+The only new failure mode is "spawn region full" (`candidates.len() < count`). That's a server-config error (too many players for the region, or too many starting units), not a runtime fault. Panic with a descriptive message — same severity as the existing `panic!("missing unit definition for {unit_type}")` immediately above it. Whichever fires, the server is unrecoverable; we want the cause loud in the log.
+
+## Testing
+
+Unit tests in `server/src/players.rs`, against the helper:
+
+1. **Distinct positions when `occupied` is empty.** Call with `count = 3`, assert the returned `Vec` has 3 elements and all distinct (round-trip through a `HashSet`).
+2. **Excludes occupied positions.** Pre-populate `occupied` with 5 chosen tiles inside the spawn region, call with `count = 3`, assert the returned positions are disjoint from `occupied` and still distinct.
+3. **Panics when the region is saturated.** Pre-populate `occupied` with 23 tiles inside the region (leaving 2), call with `count = 3`, expect panic. (`#[should_panic]`.)
+
+These cover the substance. A system-level test of `handle_new_clients` would require Bevy world setup (the existing `turn.rs` tests show this is feasible) but adds little above the helper tests — defer unless we hit a glue bug.
+
+## Alternatives considered
+
+- **Retry-loop dedup.** The other option mentioned in the issue. Equivalent random feel; rejected for retry-bound tuning and saturation behavior, as above.
+- **Deterministic squad layout with per-player anchors.** Solves a strictly larger problem (also separates players). Rejected as out-of-scope for this fix; revisit when player separation becomes a balance concern.
+- **Expand the spawn region pre-emptively** (e.g. axial radius 3 → ~37 tiles). Worth doing eventually; out of scope here because it changes feel, not just correctness. Mark the constant; revisit if/when starting-unit count or `max_clients` rises.

--- a/server/src/players.rs
+++ b/server/src/players.rs
@@ -1,14 +1,48 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
 use rand::Rng;
+use rand::seq::SliceRandom;
 use shared::events::*;
 use shared::unit_definition::UnitRegistry;
 use shared::{components::*, hex::HexPosition, units::*};
 
 use crate::turn::{PlayerState, PlayerTurnState};
+
+/// Half-extent (in axial coords) of the player-starting region.
+/// Region is the axial parallelogram q,r ∈ [-N, N] — a (2N+1)² parallelogram, NOT a hex disc.
+/// At N=2 the region has 25 tiles. With max_clients=8 and up to 3 starting units per player
+/// (24 total), this is tight but fits — bump if either rises.
+// `allow(dead_code)`: wired into `handle_new_clients` in the follow-up commit (Task 2 of issue #6).
+#[allow(dead_code)]
+const STARTING_AREA_HALF_EXTENT: i32 = 2;
+
+#[allow(dead_code)]
+fn pick_starting_positions(
+    occupied: &HashSet<HexPosition>,
+    count: usize,
+    rng: &mut impl rand::Rng,
+) -> Vec<HexPosition> {
+    let mut candidates = Vec::new();
+    for q in -STARTING_AREA_HALF_EXTENT..=STARTING_AREA_HALF_EXTENT {
+        for r in -STARTING_AREA_HALF_EXTENT..=STARTING_AREA_HALF_EXTENT {
+            let pos = HexPosition::new(q, r);
+            if !occupied.contains(&pos) {
+                candidates.push(pos);
+            }
+        }
+    }
+    if candidates.len() < count {
+        panic!(
+            "not enough free tiles for {count} starting positions: {} candidate(s) available in spawn region (half-extent {STARTING_AREA_HALF_EXTENT})",
+            candidates.len()
+        );
+    }
+    candidates.shuffle(rng);
+    candidates.into_iter().take(count).collect()
+}
 
 /// Maps ConnectedClient entity → Player entity.
 #[derive(Resource, Default)]
@@ -117,5 +151,71 @@ pub fn handle_disconnects(
             commands.entity(player_entity).despawn();
             println!("Player disconnected, despawned {player_entity}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use std::collections::HashSet;
+
+    #[test]
+    fn pick_starting_positions_returns_distinct_when_occupied_empty() {
+        let occupied: HashSet<HexPosition> = HashSet::new();
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let positions = pick_starting_positions(&occupied, 3, &mut rng);
+
+        assert_eq!(positions.len(), 3);
+        let unique: HashSet<HexPosition> = positions.iter().copied().collect();
+        assert_eq!(unique.len(), 3, "positions must be distinct");
+        for p in &positions {
+            assert!(p.q.abs() <= STARTING_AREA_HALF_EXTENT);
+            assert!(p.r.abs() <= STARTING_AREA_HALF_EXTENT);
+        }
+    }
+
+    #[test]
+    fn pick_starting_positions_excludes_occupied() {
+        let occupied: HashSet<HexPosition> = [
+            HexPosition::new(0, 0),
+            HexPosition::new(1, 0),
+            HexPosition::new(-1, 0),
+            HexPosition::new(0, 1),
+            HexPosition::new(0, -1),
+        ]
+        .into_iter()
+        .collect();
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let positions = pick_starting_positions(&occupied, 3, &mut rng);
+
+        assert_eq!(positions.len(), 3);
+        let unique: HashSet<HexPosition> = positions.iter().copied().collect();
+        assert_eq!(unique.len(), 3, "positions must be distinct");
+        for p in &positions {
+            assert!(!occupied.contains(p), "{p:?} should not be in occupied");
+            assert!(p.q.abs() <= STARTING_AREA_HALF_EXTENT);
+            assert!(p.r.abs() <= STARTING_AREA_HALF_EXTENT);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "starting positions")]
+    fn pick_starting_positions_panics_when_saturated() {
+        // Fill the 25-tile region except 2 tiles, then ask for 3.
+        let mut occupied: HashSet<HexPosition> = HashSet::new();
+        for q in -STARTING_AREA_HALF_EXTENT..=STARTING_AREA_HALF_EXTENT {
+            for r in -STARTING_AREA_HALF_EXTENT..=STARTING_AREA_HALF_EXTENT {
+                occupied.insert(HexPosition::new(q, r));
+            }
+        }
+        occupied.remove(&HexPosition::new(0, 0));
+        occupied.remove(&HexPosition::new(1, 0));
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let _ = pick_starting_positions(&occupied, 3, &mut rng);
     }
 }

--- a/server/src/players.rs
+++ b/server/src/players.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
-use rand::Rng;
 use rand::seq::SliceRandom;
 use shared::events::*;
 use shared::unit_definition::UnitRegistry;
@@ -15,11 +14,8 @@ use crate::turn::{PlayerState, PlayerTurnState};
 /// Region is the axial parallelogram q,r ∈ [-N, N] — a (2N+1)² parallelogram, NOT a hex disc.
 /// At N=2 the region has 25 tiles. With max_clients=8 and up to 3 starting units per player
 /// (24 total), this is tight but fits — bump if either rises.
-// `allow(dead_code)`: wired into `handle_new_clients` in the follow-up commit (Task 2 of issue #6).
-#[allow(dead_code)]
 const STARTING_AREA_HALF_EXTENT: i32 = 2;
 
-#[allow(dead_code)]
 fn pick_starting_positions(
     occupied: &HashSet<HexPosition>,
     count: usize,
@@ -71,11 +67,18 @@ pub struct NewPlayerSetup<'w> {
 #[allow(clippy::too_many_arguments)]
 pub fn handle_new_clients(
     new_clients: Query<Entity, Added<AuthorizedClient>>,
+    existing_units: Query<&HexPosition, With<Unit>>,
     mut commands: Commands,
     mut color_counter: ResMut<ColorCounter>,
     registry: Res<UnitRegistry>,
     mut setup: NewPlayerSetup,
 ) {
+    // Seed the occupied set from existing units; updated in-line as we
+    // assign positions so two clients added in the same frame don't collide
+    // (Commands::spawn doesn't materialize until the next system run).
+    let mut occupied: HashSet<HexPosition> = existing_units.iter().copied().collect();
+    let mut rng = rand::thread_rng();
+
     for client_entity in &new_clients {
         let color_index = color_counter.next_index();
         let player_entity = commands
@@ -110,27 +113,28 @@ pub fn handle_new_clients(
         println!("Player joined (color {color_index}), entity: {player_entity}");
 
         let starting_units = ["warrior", "settler"];
-        for unit_type in starting_units {
+        let positions = pick_starting_positions(&occupied, starting_units.len(), &mut rng);
+
+        for (unit_type, pos) in starting_units.iter().zip(positions.iter()) {
             let type_id = registry
                 .id_of(unit_type)
                 .unwrap_or_else(|| panic!("missing unit definition for {unit_type}"));
             let definition = registry
                 .get(&type_id)
                 .unwrap_or_else(|| panic!("registry has id but no definition for {unit_type}"));
-            let x = rand::thread_rng().gen_range(-2..=2);
-            let y = rand::thread_rng().gen_range(-2..=2);
             let unit_entity = commands
                 .spawn((
                     Unit { type_id },
-                    HexPosition::new(x, y),
+                    *pos,
                     Owner(player_entity),
                     ColorIndex(color_index),
                     Health::full(definition.hp),
                 ))
                 .id();
+            occupied.insert(*pos);
             println!(
-                "Spawned {unit_type}: {unit_entity} (HP {}) for player: {player_entity}",
-                definition.hp
+                "Spawned {unit_type}: {unit_entity} at ({}, {}) (HP {}) for player: {player_entity}",
+                pos.q, pos.r, definition.hp
             );
         }
     }


### PR DESCRIPTION
## Summary

- Add pure helper `pick_starting_positions(occupied, count, rng) -> Vec<HexPosition>` in `server/src/players.rs` that enumerates the spawn region (axial parallelogram `q,r ∈ [-2, 2]`, 25 tiles), filters out occupied tiles, shuffles the remainder, and returns `count` distinct positions — panicking with a descriptive message if the region is saturated.
- Wire it into `handle_new_clients` with a frame-local `occupied: HashSet<HexPosition>` seeded from `Query<&HexPosition, With<Unit>>` and updated in-line as positions are decided, so two clients authorizing on the same `Update` tick can't collide despite `Commands::spawn` not flushing between iterations.
- Three TDD'd unit tests (distinct-when-empty, excludes-occupied, panics-on-saturation).
- Combat code untouched — the start-pos uniqueness invariant the rollback chain relies on now holds at the spawn site by construction.

Design spec committed at `docs/superpowers/specs/2026-05-09-unique-starting-positions-design.md`.

Closes #6.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 33 tests pass (13 server, including 3 new helper tests; 20 shared)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Smoke: connect two clients to a fresh server, confirm the new `Spawned <unit>: <entity> at (q, r) ...` log lines show distinct `(q, r)` for all four starting units (even when both clients connect on the same frame)