### PR TITLE
City combat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Keep in mind that the game should be designed using Bevy's ECS system. For high-
 ## Coding guidelines
 - Format code with `cargo fmt`
 - Run the most relevant `cargo check` or `cargo test` command when feasible. If a command cannot be run, explain why.
-- Ensure code quality by running `cargo clippy`. Try to fix the underlying problem rather than supressing the warning. 
+- Ensure code quality by running `cargo clippy`. Try to fix the underlying problem rather than suppressing the warning. The nature of Bevy's query system makes `too_many_arguments` and `type_complexity` very common. Silencing in those situations is fine if having inlined types makes the code more readable than creating ad hoc types or SystemParams for given system just to silence the warning. 
 - Think about proper code organization. Components and systems should be separated based on their purpose, such as combat, visuals, networking, movement, turns, map generation, or input. Avoid throwing all components into one file.
 - Create new files if necessary
 - Use Rust `///` comments to describe public components, resources, events, and non-obvious systems

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -38,6 +38,23 @@ pub fn local_player_defeated(
         .is_some_and(|player| defeated.contains(player))
 }
 
+pub fn local_player_victorious(
+    controller: &Controller,
+    victorious: &Query<(), With<VictoriousPlayer>>,
+) -> bool {
+    controller
+        .player_entity
+        .is_some_and(|player| victorious.contains(player))
+}
+
+pub fn local_player_game_over(
+    controller: &Controller,
+    defeated: &Query<(), With<DefeatedPlayer>>,
+    victorious: &Query<(), With<VictoriousPlayer>>,
+) -> bool {
+    local_player_defeated(controller, defeated) || local_player_victorious(controller, victorious)
+}
+
 /// Selection / targeting state. Drives the action bar visibility and
 /// the map-highlight overlay. Idle = no unit selected.
 #[derive(Resource, Default)]
@@ -97,16 +114,17 @@ pub fn update_hex_highlights(
     all_tiles: Query<&HexPosition, With<HexTile>>,
     controller: Res<Controller>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
     players: Query<&Player>,
 ) {
     let cursor_hex = get_cursor_hex(&cursor);
     hovered.0 = cursor_hex;
 
     let player_entity = controller.player_entity;
-    let is_defeated = local_player_defeated(&controller, &defeated);
+    let is_game_over = local_player_game_over(&controller, &defeated, &victorious);
 
     // compute the current overlay set based on UiState
-    let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = if is_defeated {
+    let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = if is_game_over {
         (Vec::new(), Vec::new())
     } else {
         match *ui_state {
@@ -199,6 +217,7 @@ pub fn handle_left_click(
     cities: Query<(&HexPosition, &CityOwner), With<City>>,
     registry: Res<UnitRegistry>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
     if !mouse.just_pressed(MouseButton::Left) {
         return;
@@ -219,7 +238,7 @@ pub fn handle_left_click(
     let Some(player_entity) = controller.player_entity else {
         return;
     };
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         *ui_state = UiState::Idle;
         controller.selected_city = None;
         return;
@@ -317,6 +336,7 @@ pub fn handle_right_click(
     mut ui_state: ResMut<UiState>,
     cities: Query<(Entity, &HexPosition), With<City>>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
     if !mouse.just_pressed(MouseButton::Right) {
         return;
@@ -330,7 +350,7 @@ pub fn handle_right_click(
     if last_submitted.0.is_some_and(|t| t >= state.turn_number) {
         return;
     }
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         *ui_state = UiState::Idle;
         controller.selected_city = None;
         return;

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy_replicon::prelude::*;
 use shared::unit_definition::{UnitRegistry, is_within_attack_range, is_within_move_range};
 use shared::{
-    cities::City,
+    cities::{City, CityOwner},
     components::*,
     events::*,
     hex::{HexPosition, pixel_to_hex},
@@ -83,6 +83,7 @@ pub fn update_hex_highlights(
     mut hovered: ResMut<HoveredHex>,
     ui_state: Res<UiState>,
     units: Query<(&Unit, &HexPosition, &Owner)>,
+    cities: Query<(&HexPosition, &CityOwner), With<City>>,
     registry: Res<UnitRegistry>,
     all_tiles: Query<&HexPosition, With<HexTile>>,
     controller: Res<Controller>,
@@ -110,13 +111,21 @@ pub fn update_hex_highlights(
                     let moves = all_tiles
                         .iter()
                         .filter(|t| is_within_move_range(pos, t, def.move_budget))
+                        .filter(|t| {
+                            cities
+                                .iter()
+                                .find(|(city_pos, _)| city_pos == t)
+                                .is_none_or(|(_, city_owner)| {
+                                    city_owner.entity == player_entity || def.attack_range == 1
+                                })
+                        })
                         .copied()
                         .collect();
                     (moves, Vec::new())
                 }
                 TargetableVerb::Attack => {
                     // only enemy-occupied hexes within range light up
-                    let attacks = units
+                    let mut attacks = units
                         .iter()
                         .filter_map(|(_, p, owner)| {
                             let is_enemy = owner.0 != player_entity;
@@ -126,7 +135,15 @@ pub fn update_hex_highlights(
                                 None
                             }
                         })
-                        .collect();
+                        .collect::<Vec<_>>();
+                    attacks.extend(cities.iter().filter_map(|(p, owner)| {
+                        let is_enemy = owner.entity != player_entity;
+                        if is_enemy && is_within_attack_range(pos, p, def.attack_range) {
+                            Some(*p)
+                        } else {
+                            None
+                        }
+                    }));
                     (Vec::new(), attacks)
                 }
             }
@@ -163,6 +180,7 @@ pub fn handle_left_click(
     mut controller: ResMut<Controller>,
     mut ui_state: ResMut<UiState>,
     units: Query<(Entity, &Unit, &Owner, &HexPosition)>,
+    cities: Query<(&HexPosition, &CityOwner), With<City>>,
     registry: Res<UnitRegistry>,
 ) {
     if !mouse.just_pressed(MouseButton::Left) {
@@ -227,7 +245,11 @@ pub fn handle_left_click(
             };
             match verb {
                 TargetableVerb::Move => {
-                    if is_within_move_range(pos, &target, def.move_budget) {
+                    let city_at_target = cities.iter().find(|(city_pos, _)| **city_pos == target);
+                    let valid_city_target = city_at_target.is_none_or(|(_, city_owner)| {
+                        city_owner.entity == player_entity || def.attack_range == 1
+                    });
+                    if is_within_move_range(pos, &target, def.move_budget) && valid_city_target {
                         commands.client_trigger(UnitActionEvent {
                             unit,
                             action: UnitAction::Move { target },
@@ -242,7 +264,10 @@ pub fn handle_left_click(
                     // attacker is at `pos`; enemies are units with a different owner_id at `target`
                     let enemy_here = units
                         .iter()
-                        .any(|(_, _, owner, p)| *p == target && owner.0 != player_entity);
+                        .any(|(_, _, owner, p)| *p == target && owner.0 != player_entity)
+                        || cities
+                            .iter()
+                            .any(|(p, owner)| *p == target && owner.entity != player_entity);
                     if is_within_attack_range(pos, &target, def.attack_range) && enemy_here {
                         commands.client_trigger(UnitActionEvent {
                             unit,

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -29,6 +29,15 @@ pub struct Controller {
     pub selected_city: Option<Entity>,
 }
 
+pub fn local_player_defeated(
+    controller: &Controller,
+    defeated: &Query<(), With<DefeatedPlayer>>,
+) -> bool {
+    controller
+        .player_entity
+        .is_some_and(|player| defeated.contains(player))
+}
+
 /// Selection / targeting state. Drives the action bar visibility and
 /// the map-highlight overlay. Idle = no unit selected.
 #[derive(Resource, Default)]
@@ -87,68 +96,75 @@ pub fn update_hex_highlights(
     registry: Res<UnitRegistry>,
     all_tiles: Query<&HexPosition, With<HexTile>>,
     controller: Res<Controller>,
+    defeated: Query<(), With<DefeatedPlayer>>,
     players: Query<&Player>,
 ) {
     let cursor_hex = get_cursor_hex(&cursor);
     hovered.0 = cursor_hex;
 
-    let Some(player_entity) = controller.player_entity else {
-        return;
-    };
+    let player_entity = controller.player_entity;
+    let is_defeated = local_player_defeated(&controller, &defeated);
 
     // compute the current overlay set based on UiState
-    let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = match *ui_state {
-        UiState::Targeting { unit, verb } => 'overlay: {
-            let Ok((u, pos, _)) = units.get(unit) else {
-                // stale unit ref — fall through with no overlay so the loop repaints to default
-                break 'overlay (Vec::new(), Vec::new());
-            };
-            let Some(def) = registry.get(&u.type_id) else {
-                break 'overlay (Vec::new(), Vec::new());
-            };
-            match verb {
-                TargetableVerb::Move => {
-                    let moves = all_tiles
-                        .iter()
-                        .filter(|t| is_within_move_range(pos, t, def.move_budget))
-                        .filter(|t| {
-                            cities
-                                .iter()
-                                .find(|(city_pos, _)| city_pos == t)
-                                .is_none_or(|(_, city_owner)| {
-                                    city_owner.entity == player_entity || def.attack_range == 1
-                                })
-                        })
-                        .copied()
-                        .collect();
-                    (moves, Vec::new())
-                }
-                TargetableVerb::Attack => {
-                    // only enemy-occupied hexes within range light up
-                    let mut attacks = units
-                        .iter()
-                        .filter_map(|(_, p, owner)| {
-                            let is_enemy = owner.0 != player_entity;
+    let (move_targets, attack_targets): (Vec<HexPosition>, Vec<HexPosition>) = if is_defeated {
+        (Vec::new(), Vec::new())
+    } else {
+        match *ui_state {
+            UiState::Targeting { unit, verb } => 'overlay: {
+                let Some(player_entity) = player_entity else {
+                    break 'overlay (Vec::new(), Vec::new());
+                };
+                let Ok((u, pos, _)) = units.get(unit) else {
+                    // stale unit ref — fall through with no overlay so the loop repaints to default
+                    break 'overlay (Vec::new(), Vec::new());
+                };
+                let Some(def) = registry.get(&u.type_id) else {
+                    break 'overlay (Vec::new(), Vec::new());
+                };
+                match verb {
+                    TargetableVerb::Move => {
+                        let moves = all_tiles
+                            .iter()
+                            .filter(|t| is_within_move_range(pos, t, def.move_budget))
+                            .filter(|t| {
+                                cities
+                                    .iter()
+                                    .find(|(city_pos, _)| city_pos == t)
+                                    .is_none_or(|(_, city_owner)| {
+                                        city_owner.entity == player_entity || def.attack_range == 1
+                                    })
+                            })
+                            .copied()
+                            .collect();
+                        (moves, Vec::new())
+                    }
+                    TargetableVerb::Attack => {
+                        // only enemy-occupied hexes within range light up
+                        let mut attacks = units
+                            .iter()
+                            .filter_map(|(_, p, owner)| {
+                                let is_enemy = owner.0 != player_entity;
+                                if is_enemy && is_within_attack_range(pos, p, def.attack_range) {
+                                    Some(*p)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        attacks.extend(cities.iter().filter_map(|(p, owner)| {
+                            let is_enemy = owner.entity != player_entity;
                             if is_enemy && is_within_attack_range(pos, p, def.attack_range) {
                                 Some(*p)
                             } else {
                                 None
                             }
-                        })
-                        .collect::<Vec<_>>();
-                    attacks.extend(cities.iter().filter_map(|(p, owner)| {
-                        let is_enemy = owner.entity != player_entity;
-                        if is_enemy && is_within_attack_range(pos, p, def.attack_range) {
-                            Some(*p)
-                        } else {
-                            None
-                        }
-                    }));
-                    (Vec::new(), attacks)
+                        }));
+                        (Vec::new(), attacks)
+                    }
                 }
             }
+            _ => (Vec::new(), Vec::new()),
         }
-        _ => (Vec::new(), Vec::new()),
     };
 
     for (pos, owner, mut material) in &mut tiles {
@@ -182,6 +198,7 @@ pub fn handle_left_click(
     units: Query<(Entity, &Unit, &Owner, &HexPosition)>,
     cities: Query<(&HexPosition, &CityOwner), With<City>>,
     registry: Res<UnitRegistry>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
     if !mouse.just_pressed(MouseButton::Left) {
         return;
@@ -202,6 +219,11 @@ pub fn handle_left_click(
     let Some(player_entity) = controller.player_entity else {
         return;
     };
+    if local_player_defeated(&controller, &defeated) {
+        *ui_state = UiState::Idle;
+        controller.selected_city = None;
+        return;
+    }
 
     // is the click on one of my owned units?
     let owned_unit_at = |hex: HexPosition| -> Option<Entity> {
@@ -285,6 +307,7 @@ pub fn handle_left_click(
 
 /// Allows selecting both unit/city when they are on the same tile. This is a temporary solution
 /// Better handling of user input / gui should be considered in the future
+#[allow(clippy::too_many_arguments)]
 pub fn handle_right_click(
     mouse: Res<ButtonInput<MouseButton>>,
     cursor: CursorWorld,
@@ -293,6 +316,7 @@ pub fn handle_right_click(
     mut controller: ResMut<Controller>,
     mut ui_state: ResMut<UiState>,
     cities: Query<(Entity, &HexPosition), With<City>>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
     if !mouse.just_pressed(MouseButton::Right) {
         return;
@@ -304,6 +328,11 @@ pub fn handle_right_click(
         return;
     }
     if last_submitted.0.is_some_and(|t| t >= state.turn_number) {
+        return;
+    }
+    if local_player_defeated(&controller, &defeated) {
+        *ui_state = UiState::Idle;
+        controller.selected_city = None;
         return;
     }
 

--- a/client/src/lobby.rs
+++ b/client/src/lobby.rs
@@ -1,12 +1,13 @@
 use bevy::prelude::*;
 use bevy_replicon::prelude::ClientTriggerExt;
 use shared::components::{
-    DefeatedPlayer, Host, PLAYER_COLORS, Player, TurnPhase, TurnState, WaitingPlayer,
+    DefeatedPlayer, Host, PLAYER_COLORS, Player, TurnPhase, TurnState, VictoriousPlayer,
+    WaitingPlayer,
 };
 use shared::events::StartGame;
 
 use crate::input::Controller;
-use crate::input::local_player_defeated;
+use crate::input::local_player_game_over;
 
 #[derive(Component)]
 pub struct LobbyOverlay;
@@ -297,6 +298,7 @@ pub fn update_lobby_ui(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_start_game_click(
     click: On<Pointer<Click>>,
     mut commands: Commands,
@@ -305,11 +307,12 @@ pub fn handle_start_game_click(
     players: Query<(), With<Player>>,
     controller: Res<Controller>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
     if !buttons.contains(click.entity) {
         return;
     }
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         return;
     }
     let Ok(state) = turn_state.single() else {

--- a/client/src/lobby.rs
+++ b/client/src/lobby.rs
@@ -1,9 +1,12 @@
 use bevy::prelude::*;
 use bevy_replicon::prelude::ClientTriggerExt;
-use shared::components::{Host, PLAYER_COLORS, Player, TurnPhase, TurnState, WaitingPlayer};
+use shared::components::{
+    DefeatedPlayer, Host, PLAYER_COLORS, Player, TurnPhase, TurnState, WaitingPlayer,
+};
 use shared::events::StartGame;
 
 use crate::input::Controller;
+use crate::input::local_player_defeated;
 
 #[derive(Component)]
 pub struct LobbyOverlay;
@@ -300,8 +303,13 @@ pub fn handle_start_game_click(
     buttons: Query<(), With<StartGameButton>>,
     turn_state: Query<&TurnState>,
     players: Query<(), With<Player>>,
+    controller: Res<Controller>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
     if !buttons.contains(click.entity) {
+        return;
+    }
+    if local_player_defeated(&controller, &defeated) {
         return;
     }
     let Ok(state) = turn_state.single() else {

--- a/client/src/lobby.rs
+++ b/client/src/lobby.rs
@@ -213,7 +213,7 @@ pub fn update_lobby_ui(
     }
 
     // Rebuild player list only when its contents change.
-    // Sort by slot_index so the display order matches the server's compact ordering.
+    // Sort by color_index so the display order matches the server's compact ordering.
     let mut sorted_players: Vec<(u8, Entity)> =
         players.iter().map(|(e, p)| (p.color_index, e)).collect();
     sorted_players.sort();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -103,6 +103,7 @@ fn main() {
                     update_action_bar,
                     update_production_bar,
                     update_lobby_ui,
+                    update_lose_screen,
                 ),
             ),
         )

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -84,6 +84,7 @@ fn main() {
                     update_city_visuals,
                     update_unit_positions,
                     update_unit_health_bars,
+                    update_city_health_bars,
                 ),
                 (
                     move_camera_with_keyboard,

--- a/client/src/ui.rs
+++ b/client/src/ui.rs
@@ -7,7 +7,10 @@ use shared::production::{CityProduction, ProductionOutput, ProductionRecipeId, R
 use shared::unit_definition::{UnitRegistry, UnitVerb, available_verbs};
 use shared::units::Unit;
 
-use crate::input::{Controller, LastSubmittedTurn, TargetableVerb, UiState, local_player_defeated};
+use crate::input::{
+    Controller, LastSubmittedTurn, TargetableVerb, UiState, local_player_defeated,
+    local_player_game_over, local_player_victorious,
+};
 
 #[derive(Component)]
 pub struct TurnUiText;
@@ -32,6 +35,9 @@ pub struct ProductionButton(pub Option<ProductionRecipeId>);
 
 #[derive(Component)]
 pub struct LoseScreen;
+
+#[derive(Component)]
+pub struct VictoryScreen;
 
 pub fn spawn_turn_ui(mut commands: Commands) {
     commands.spawn((
@@ -173,6 +179,43 @@ pub fn spawn_turn_ui(mut commands: Commands) {
             )
         ],
     ));
+
+    commands.spawn((
+        VictoryScreen,
+        Node {
+            position_type: PositionType::Absolute,
+            left: Val::Px(0.0),
+            right: Val::Px(0.0),
+            top: Val::Px(0.0),
+            bottom: Val::Px(0.0),
+            display: Display::None,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            flex_direction: FlexDirection::Column,
+            row_gap: Val::Px(16.0),
+            ..default()
+        },
+        BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.85)),
+        GlobalZIndex(100),
+        children![
+            (
+                Text::new("You won"),
+                TextFont {
+                    font_size: 64.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.1, 0.85, 0.25)),
+            ),
+            (
+                Text::new("Close the app to leave the game."),
+                TextFont {
+                    font_size: 24.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+            )
+        ],
+    ));
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -185,8 +228,9 @@ pub fn finish_turn_clicked(
     mut ui_state: ResMut<UiState>,
     controller: Res<Controller>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         return;
     }
     let Ok(state) = turn_state.single() else {
@@ -204,6 +248,7 @@ pub fn update_turn_ui(
     controller: Res<Controller>,
     last_submitted: Res<LastSubmittedTurn>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
     mut ui_text: Query<&mut Text, With<TurnUiText>>,
 ) {
     let Ok(mut text) = ui_text.single_mut() else {
@@ -216,6 +261,10 @@ pub fn update_turn_ui(
     }
     if local_player_defeated(&controller, &defeated) {
         **text = "You lost".to_string();
+        return;
+    }
+    if local_player_victorious(&controller, &victorious) {
+        **text = "You won".to_string();
         return;
     }
 
@@ -373,13 +422,14 @@ pub fn update_production_bar(
     controller: Res<Controller>,
     cities: Query<&CityOwner, With<City>>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
     mut bars: Query<&mut Node, With<ProductionBar>>,
 ) {
-    if !controller.is_changed() && defeated.is_empty() {
+    if !controller.is_changed() && defeated.is_empty() && victorious.is_empty() {
         return;
     }
 
-    let show = !local_player_defeated(&controller, &defeated)
+    let show = !local_player_game_over(&controller, &defeated, &victorious)
         && controller
             .selected_city
             .and_then(|city| cities.get(city).ok())
@@ -391,6 +441,7 @@ pub fn update_production_bar(
 }
 
 // reacts to UiState changes: shows/hides bar, sets enabled/greyed buttons
+#[allow(clippy::too_many_arguments)]
 pub fn update_action_bar(
     ui_state: Res<UiState>,
     mut bars: Query<&mut Node, (With<ActionBar>, Without<VerbButton>)>,
@@ -399,11 +450,12 @@ pub fn update_action_bar(
     registry: Res<UnitRegistry>,
     controller: Res<Controller>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
-    if !ui_state.is_changed() && defeated.is_empty() {
+    if !ui_state.is_changed() && defeated.is_empty() && victorious.is_empty() {
         return;
     }
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         for mut node in &mut bars {
             node.display = Display::None;
         }
@@ -464,8 +516,9 @@ pub fn handle_verb_button_click(
     last_submitted: Res<LastSubmittedTurn>,
     controller: Res<Controller>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         *ui_state = UiState::Idle;
         return;
     }
@@ -557,6 +610,7 @@ pub fn handle_verb_button_click(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_production_button_click(
     click: On<Pointer<Click>>,
     mut commands: Commands,
@@ -565,8 +619,9 @@ pub fn handle_production_button_click(
     turn_state: Query<&TurnState>,
     last_submitted: Res<LastSubmittedTurn>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
-    if local_player_defeated(&controller, &defeated) {
+    if local_player_game_over(&controller, &defeated, &victorious) {
         return;
     }
     let Ok(button) = buttons.get(click.entity) else {
@@ -595,14 +650,20 @@ pub fn handle_production_button_click(
 pub fn update_lose_screen(
     controller: Res<Controller>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
     mut screens: Query<&mut Node, With<LoseScreen>>,
+    mut victory_screens: Query<&mut Node, (With<VictoryScreen>, Without<LoseScreen>)>,
     mut ui_state: ResMut<UiState>,
 ) {
     let lost = local_player_defeated(&controller, &defeated);
-    if lost {
+    let won = local_player_victorious(&controller, &victorious);
+    if lost || won {
         *ui_state = UiState::Idle;
     }
     for mut node in &mut screens {
         node.display = if lost { Display::Flex } else { Display::None };
+    }
+    for mut node in &mut victory_screens {
+        node.display = if won { Display::Flex } else { Display::None };
     }
 }

--- a/client/src/ui.rs
+++ b/client/src/ui.rs
@@ -7,7 +7,7 @@ use shared::production::{CityProduction, ProductionOutput, ProductionRecipeId, R
 use shared::unit_definition::{UnitRegistry, UnitVerb, available_verbs};
 use shared::units::Unit;
 
-use crate::input::{Controller, LastSubmittedTurn, TargetableVerb, UiState};
+use crate::input::{Controller, LastSubmittedTurn, TargetableVerb, UiState, local_player_defeated};
 
 #[derive(Component)]
 pub struct TurnUiText;
@@ -29,6 +29,9 @@ pub struct ProductionBar;
 
 #[derive(Component)]
 pub struct ProductionButton(pub Option<ProductionRecipeId>);
+
+#[derive(Component)]
+pub struct LoseScreen;
 
 pub fn spawn_turn_ui(mut commands: Commands) {
     commands.spawn((
@@ -133,8 +136,46 @@ pub fn spawn_turn_ui(mut commands: Commands) {
             ..default()
         },
     ));
+
+    commands.spawn((
+        LoseScreen,
+        Node {
+            position_type: PositionType::Absolute,
+            left: Val::Px(0.0),
+            right: Val::Px(0.0),
+            top: Val::Px(0.0),
+            bottom: Val::Px(0.0),
+            display: Display::None,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            flex_direction: FlexDirection::Column,
+            row_gap: Val::Px(16.0),
+            ..default()
+        },
+        BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.85)),
+        GlobalZIndex(100),
+        children![
+            (
+                Text::new("You lost"),
+                TextFont {
+                    font_size: 64.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.9, 0.1, 0.1)),
+            ),
+            (
+                Text::new("Close the app to leave the game."),
+                TextFont {
+                    font_size: 24.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+            )
+        ],
+    ));
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn finish_turn_clicked(
     click: On<Pointer<Click>>,
     mut commands: Commands,
@@ -142,7 +183,12 @@ pub fn finish_turn_clicked(
     turn_state: Query<&TurnState>,
     mut last_submitted: ResMut<LastSubmittedTurn>,
     mut ui_state: ResMut<UiState>,
+    controller: Res<Controller>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
+    if local_player_defeated(&controller, &defeated) {
+        return;
+    }
     let Ok(state) = turn_state.single() else {
         return;
     };
@@ -157,6 +203,7 @@ pub fn update_turn_ui(
     turn_state: Query<&TurnState>,
     controller: Res<Controller>,
     last_submitted: Res<LastSubmittedTurn>,
+    defeated: Query<(), With<DefeatedPlayer>>,
     mut ui_text: Query<&mut Text, With<TurnUiText>>,
 ) {
     let Ok(mut text) = ui_text.single_mut() else {
@@ -165,6 +212,10 @@ pub fn update_turn_ui(
 
     if controller.player_entity.is_none() {
         **text = "Connecting...".to_string();
+        return;
+    }
+    if local_player_defeated(&controller, &defeated) {
+        **text = "You lost".to_string();
         return;
     }
 
@@ -321,16 +372,18 @@ fn format_recipe_progress(
 pub fn update_production_bar(
     controller: Res<Controller>,
     cities: Query<&CityOwner, With<City>>,
+    defeated: Query<(), With<DefeatedPlayer>>,
     mut bars: Query<&mut Node, With<ProductionBar>>,
 ) {
-    if !controller.is_changed() {
+    if !controller.is_changed() && defeated.is_empty() {
         return;
     }
 
-    let show = controller
-        .selected_city
-        .and_then(|city| cities.get(city).ok())
-        .is_some_and(|owner| Some(owner.entity) == controller.player_entity);
+    let show = !local_player_defeated(&controller, &defeated)
+        && controller
+            .selected_city
+            .and_then(|city| cities.get(city).ok())
+            .is_some_and(|owner| Some(owner.entity) == controller.player_entity);
 
     for mut node in &mut bars {
         node.display = if show { Display::Flex } else { Display::None };
@@ -344,8 +397,16 @@ pub fn update_action_bar(
     mut buttons: Query<(&VerbButton, &mut BackgroundColor)>,
     units: Query<&Unit>,
     registry: Res<UnitRegistry>,
+    controller: Res<Controller>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
-    if !ui_state.is_changed() {
+    if !ui_state.is_changed() && defeated.is_empty() {
+        return;
+    }
+    if local_player_defeated(&controller, &defeated) {
+        for mut node in &mut bars {
+            node.display = Display::None;
+        }
         return;
     }
     let unit_entity = match *ui_state {
@@ -401,7 +462,13 @@ pub fn handle_verb_button_click(
     registry: Res<UnitRegistry>,
     turn_state: Query<&TurnState>,
     last_submitted: Res<LastSubmittedTurn>,
+    controller: Res<Controller>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
+    if local_player_defeated(&controller, &defeated) {
+        *ui_state = UiState::Idle;
+        return;
+    }
     let Ok(VerbButton(verb)) = buttons.get(click.entity) else {
         return;
     };
@@ -497,7 +564,11 @@ pub fn handle_production_button_click(
     controller: Res<Controller>,
     turn_state: Query<&TurnState>,
     last_submitted: Res<LastSubmittedTurn>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
+    if local_player_defeated(&controller, &defeated) {
+        return;
+    }
     let Ok(button) = buttons.get(click.entity) else {
         return;
     };
@@ -519,4 +590,19 @@ pub fn handle_production_button_click(
         None => CityAction::ClearProduction,
     };
     commands.client_trigger(CityActionEvent { city, action });
+}
+
+pub fn update_lose_screen(
+    controller: Res<Controller>,
+    defeated: Query<(), With<DefeatedPlayer>>,
+    mut screens: Query<&mut Node, With<LoseScreen>>,
+    mut ui_state: ResMut<UiState>,
+) {
+    let lost = local_player_defeated(&controller, &defeated);
+    if lost {
+        *ui_state = UiState::Idle;
+    }
+    for mut node in &mut screens {
+        node.display = if lost { Display::Flex } else { Display::None };
+    }
 }

--- a/client/src/visuals.rs
+++ b/client/src/visuals.rs
@@ -2,7 +2,7 @@ mod cities;
 mod hexes;
 mod units;
 
-pub use cities::{spawn_city_visuals, update_city_visuals};
+pub use cities::{spawn_city_visuals, update_city_health_bars, update_city_visuals};
 pub use hexes::{HexMaterials, setup_hex_materials, spawn_hex_visuals};
 pub use units::{
     spawn_unit_visuals, update_unit_colors, update_unit_health_bars, update_unit_positions,

--- a/client/src/visuals/cities.rs
+++ b/client/src/visuals/cities.rs
@@ -1,14 +1,20 @@
 use bevy::prelude::*;
+use bevy::sprite::Anchor;
 use shared::{
     cities::{City, CityStats},
     components::player_color,
     hex::{HexPosition, hex_to_pixel},
-    units::ColorIndex,
+    units::{ColorIndex, Health},
 };
 
 use crate::HEX_SIZE;
 
 const CITY_SPRITE_SIZE: f32 = 58.0;
+const CITY_HEALTH_BAR_WIDTH: f32 = 42.0;
+const CITY_HEALTH_BAR_HEIGHT: f32 = 10.0;
+const CITY_HEALTH_BAR_OFFSET: Vec3 = Vec3::new(0.0, 48.0, 0.8);
+const CITY_HEALTH_BAR_FONT_SIZE: f32 = 10.0;
+const CITY_HEALTH_BAR_FILL_COLOR: Color = Color::srgb(0.02, 0.12, 0.65);
 
 #[derive(Clone, Copy)]
 enum CityVisualTier {
@@ -16,6 +22,28 @@ enum CityVisualTier {
     Medium,
     Large,
 }
+
+#[derive(Component)]
+pub(crate) struct CityVisual {
+    team_mask: Entity,
+}
+
+#[derive(Component)]
+pub(crate) struct CityHealthBar {
+    fill: Entity,
+    text: Entity,
+}
+
+#[derive(Component)]
+pub(crate) struct CityTeamMask;
+
+#[derive(Component)]
+pub(crate) struct CityHealthBarFill;
+
+#[derive(Component)]
+pub(crate) struct CityHealthBarText;
+
+type CityHealthBarFillFilter = (With<CityHealthBarFill>, Without<City>);
 
 pub fn spawn_city_visuals(
     cities: Query<(Entity, &HexPosition, &CityStats, &ColorIndex), Added<City>>,
@@ -29,6 +57,9 @@ pub fn spawn_city_visuals(
         let (texture, team_mask_texture) = tier.texture_paths();
 
         println!("Adding city: {entity}, at pixel {pixel}");
+        let mut team_mask = None;
+        let mut health_bar_fill = None;
+        let mut health_bar_text = None;
         commands
             .entity(entity)
             .insert((
@@ -36,35 +67,116 @@ pub fn spawn_city_visuals(
                 Transform::from_xyz(pixel.x, pixel.y, 1.5),
             ))
             .with_children(|parent| {
-                parent.spawn((
-                    city_sprite(asset_server.load(team_mask_texture), color),
-                    Transform::from_xyz(0.0, 0.0, 0.1),
+                team_mask = Some(
+                    parent
+                        .spawn((
+                            CityTeamMask,
+                            city_sprite(asset_server.load(team_mask_texture), color),
+                            Transform::from_xyz(0.0, 0.0, 0.1),
+                        ))
+                        .id(),
+                );
+
+                let mut health_bar = parent.spawn((
+                    Sprite {
+                        color: Color::srgba(0.05, 0.05, 0.05, 0.9),
+                        custom_size: Some(Vec2::new(CITY_HEALTH_BAR_WIDTH, CITY_HEALTH_BAR_HEIGHT)),
+                        ..default()
+                    },
+                    Transform::from_translation(CITY_HEALTH_BAR_OFFSET),
                 ));
+
+                health_bar.with_children(|bar| {
+                    health_bar_fill = Some(
+                        bar.spawn((
+                            CityHealthBarFill,
+                            Sprite {
+                                color: CITY_HEALTH_BAR_FILL_COLOR,
+                                custom_size: Some(Vec2::new(
+                                    CITY_HEALTH_BAR_WIDTH,
+                                    CITY_HEALTH_BAR_HEIGHT,
+                                )),
+                                ..default()
+                            },
+                            Transform::from_xyz(0.0, 0.0, 0.1),
+                        ))
+                        .id(),
+                    );
+
+                    health_bar_text = Some(
+                        bar.spawn((
+                            CityHealthBarText,
+                            Text2d::new(""),
+                            TextFont {
+                                font_size: CITY_HEALTH_BAR_FONT_SIZE,
+                                ..default()
+                            },
+                            TextColor(Color::WHITE),
+                            Anchor::CENTER,
+                            Transform::from_xyz(0.0, 0.0, 0.2),
+                        ))
+                        .id(),
+                    );
+                });
             });
+
+        commands.entity(entity).insert((
+            CityVisual {
+                team_mask: team_mask.expect("city team mask should be spawned"),
+            },
+            CityHealthBar {
+                fill: health_bar_fill.expect("city health bar fill should be spawned"),
+                text: health_bar_text.expect("city health bar text should be spawned"),
+            },
+        ));
     }
 }
 
 #[allow(clippy::type_complexity)]
 pub fn update_city_visuals(
     cities: Query<
-        (&CityStats, &ColorIndex, &mut Sprite, &Children),
+        (&CityStats, &ColorIndex, &mut Sprite, &CityVisual),
         (With<City>, Or<(Changed<CityStats>, Changed<ColorIndex>)>),
     >,
-    mut sprites: Query<&mut Sprite, Without<City>>,
+    mut masks: Query<&mut Sprite, (With<CityTeamMask>, Without<City>)>,
     asset_server: Res<AssetServer>,
 ) {
-    for (stats, color_index, mut sprite, children) in cities {
+    for (stats, color_index, mut sprite, visual) in cities {
         let tier = CityVisualTier::for_border_range(stats.border_range);
         let (texture, team_mask_texture) = tier.texture_paths();
         let color = player_color(color_index.0);
 
         sprite.image = asset_server.load(texture);
-        for child in children {
-            let Ok(mut mask_sprite) = sprites.get_mut(*child) else {
-                continue;
-            };
+        if let Ok(mut mask_sprite) = masks.get_mut(visual.team_mask) {
             mask_sprite.image = asset_server.load(team_mask_texture);
             mask_sprite.color = color;
+        }
+    }
+}
+
+pub fn update_city_health_bars(
+    cities: Query<(&Health, &CityHealthBar), With<City>>,
+    mut bar_fills: Query<(&mut Sprite, &mut Transform), CityHealthBarFillFilter>,
+    mut bar_texts: Query<&mut Text2d, With<CityHealthBarText>>,
+) {
+    for (health, health_bar) in &cities {
+        let Ok((mut fill_sprite, mut fill_transform)) = bar_fills.get_mut(health_bar.fill) else {
+            continue;
+        };
+
+        let health_fraction = if health.max == 0 {
+            0.0
+        } else {
+            health.current as f32 / health.max as f32
+        }
+        .clamp(0.0, 1.0);
+        let fill_width = CITY_HEALTH_BAR_WIDTH * health_fraction;
+
+        fill_sprite.custom_size = Some(Vec2::new(fill_width, CITY_HEALTH_BAR_HEIGHT));
+        fill_transform.translation.x = (fill_width - CITY_HEALTH_BAR_WIDTH) * 0.5;
+
+        if let Ok(mut text) = bar_texts.get_mut(health_bar.text) {
+            text.0 = format!("{}/{}", health.current, health.max);
         }
     }
 }

--- a/server/src/cities.rs
+++ b/server/src/cities.rs
@@ -20,11 +20,15 @@ pub const POPULATION_PER_BORDER_RANGE: u32 = 3;
 pub const FOOD_GROWTH_MULTIPLIER: i32 = 5;
 pub const CITY_MAX_HP: u32 = 20;
 pub const CITY_CAPTURE_HP: u32 = 10;
+pub const CITY_REGEN_PER_TURN: u32 = 2;
 
 #[derive(EntityEvent)]
 pub struct GrowCity {
     pub entity: Entity,
 }
+
+#[derive(Component)]
+pub struct CityAttackedThisTurn;
 
 /// Spawns a city controlled by `player_id` at the given map tile.
 pub fn spawn_city_at_tile(

--- a/server/src/cities.rs
+++ b/server/src/cities.rs
@@ -4,7 +4,7 @@ use shared::{
     hex::HexPosition,
     production::CityProduction,
     tiles::{TileOwner, TileResources},
-    units::ColorIndex,
+    units::{ColorIndex, Health},
 };
 
 pub const DEFAULT_TILE_RESOURCES: TileResources = TileResources {
@@ -18,6 +18,8 @@ pub const STARTING_BORDER_RANGE: i32 = 1;
 pub const MAX_BORDER_RANGE: i32 = 3;
 pub const POPULATION_PER_BORDER_RANGE: u32 = 3;
 pub const FOOD_GROWTH_MULTIPLIER: i32 = 5;
+pub const CITY_MAX_HP: u32 = 20;
+pub const CITY_CAPTURE_HP: u32 = 10;
 
 #[derive(EntityEvent)]
 pub struct GrowCity {
@@ -48,6 +50,7 @@ pub fn spawn_city_at_tile(
                 entity: player_entity,
             },
             ColorIndex(color_index),
+            Health::full(CITY_MAX_HP),
         ))
         .id();
     commands.trigger(GrowCity { entity });

--- a/server/src/cities_systems.rs
+++ b/server/src/cities_systems.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy_replicon::prelude::{ClientId, FromClient};
 use shared::{
     cities::*,
-    components::{HexTile, Player, TurnPhase, TurnState},
+    components::{DefeatedPlayer, HexTile, Player, TurnPhase, TurnState},
     events::{CityAction, CityActionEvent},
     hex::HexPosition,
     production::{CityProduction, ProductionOutput, RecipeRegistry},
@@ -68,6 +68,7 @@ pub fn handle_city_action(
     recipes: Res<RecipeRegistry>,
     turn_state: Query<&TurnState>,
     mut cities: Query<(&CityOwner, &mut CityProduction), With<City>>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
     let Ok(state) = turn_state.single() else {
         return;
@@ -83,6 +84,9 @@ pub fn handle_city_action(
     let Some(player_entity) = player_map.client_to_player.get(&client_entity) else {
         return;
     };
+    if defeated.contains(*player_entity) {
+        return;
+    }
 
     let Ok((owner, mut production)) = cities.get_mut(trigger.message.city) else {
         return;

--- a/server/src/cities_systems.rs
+++ b/server/src/cities_systems.rs
@@ -62,6 +62,30 @@ pub fn grant_city_gold(
     }
 }
 
+pub fn regenerate_unattacked_cities(
+    mut commands: Commands,
+    mut cities: Query<(Entity, &mut Health, Option<&CityAttackedThisTurn>), With<City>>,
+) {
+    for (entity, mut health, attacked) in &mut cities {
+        if attacked.is_some() {
+            commands.entity(entity).remove::<CityAttackedThisTurn>();
+            continue;
+        }
+        if health.current >= health.max {
+            continue;
+        }
+        let before = health.current;
+        health.current = health
+            .current
+            .saturating_add(CITY_REGEN_PER_TURN)
+            .min(health.max);
+        println!(
+            "City regen: {entity} hp {} -> {} (+{})",
+            before, health.current, CITY_REGEN_PER_TURN
+        );
+    }
+}
+
 pub fn handle_city_action(
     trigger: On<FromClient<CityActionEvent>>,
     player_map: Res<PlayerMap>,
@@ -219,5 +243,79 @@ pub fn recalculate_city_yields(
         stats.food_per_turn = food_per_turn;
         stats.production = production;
         stats.gold_per_turn = gold_per_turn;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::hex::HexPosition;
+
+    #[test]
+    fn regenerate_unattacked_cities_heals_damaged_city() {
+        let mut app = App::new();
+        app.add_systems(Update, regenerate_unattacked_cities);
+
+        let city = app
+            .world_mut()
+            .spawn((
+                City,
+                HexPosition::new(0, 0),
+                Health {
+                    current: 10,
+                    max: 20,
+                },
+            ))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 12);
+    }
+
+    #[test]
+    fn regenerate_unattacked_cities_skips_attacked_city_and_clears_marker() {
+        let mut app = App::new();
+        app.add_systems(Update, regenerate_unattacked_cities);
+
+        let city = app
+            .world_mut()
+            .spawn((
+                City,
+                CityAttackedThisTurn,
+                HexPosition::new(0, 0),
+                Health {
+                    current: 10,
+                    max: 20,
+                },
+            ))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 10);
+        assert!(app.world().get::<CityAttackedThisTurn>(city).is_none());
+    }
+
+    #[test]
+    fn regenerate_unattacked_cities_does_not_exceed_max_hp() {
+        let mut app = App::new();
+        app.add_systems(Update, regenerate_unattacked_cities);
+
+        let city = app
+            .world_mut()
+            .spawn((
+                City,
+                HexPosition::new(0, 0),
+                Health {
+                    current: 19,
+                    max: 20,
+                },
+            ))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 20);
     }
 }

--- a/server/src/cities_systems.rs
+++ b/server/src/cities_systems.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy_replicon::prelude::{ClientId, FromClient};
 use shared::{
     cities::*,
-    components::{DefeatedPlayer, HexTile, Player, TurnPhase, TurnState},
+    components::{DefeatedPlayer, HexTile, Player, TurnPhase, TurnState, VictoriousPlayer},
     events::{CityAction, CityActionEvent},
     hex::HexPosition,
     production::{CityProduction, ProductionOutput, RecipeRegistry},
@@ -69,6 +69,7 @@ pub fn handle_city_action(
     turn_state: Query<&TurnState>,
     mut cities: Query<(&CityOwner, &mut CityProduction), With<City>>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
     let Ok(state) = turn_state.single() else {
         return;
@@ -85,6 +86,9 @@ pub fn handle_city_action(
         return;
     };
     if defeated.contains(*player_entity) {
+        return;
+    }
+    if victorious.contains(*player_entity) {
         return;
     }
 

--- a/server/src/combat/algorithm.rs
+++ b/server/src/combat/algorithm.rs
@@ -2,7 +2,7 @@ use bevy::prelude::Entity;
 use shared::hex::HexPosition;
 use std::collections::{HashMap, HashSet};
 
-use super::types::{CombatDeltas, ResolveAction, UnitSnapshot};
+use super::types::{CityCapture, CitySnapshot, CombatDeltas, ResolveAction, UnitSnapshot};
 
 /// Pure combat resolver. Borrows snapshots so the wrapper can keep the Vec
 /// around for logging without cloning.
@@ -15,7 +15,11 @@ use super::types::{CombatDeltas, ResolveAction, UnitSnapshot};
 /// Iteration stops when no conflict remains. Termination is guaranteed by
 /// `start_pos` uniqueness (enforced by handle_unit_action's friendly-stack
 /// checks); the 256-iteration cap is a sanity guard.
-pub fn resolve_movement_pure(units: &[UnitSnapshot]) -> CombatDeltas {
+pub fn resolve_movement_pure(
+    units: &[UnitSnapshot],
+    cities: &[CitySnapshot],
+    city_capture_hp: u32,
+) -> CombatDeltas {
     // Snapshot-derived indices and initial working state.
     let initial_hps: HashMap<Entity, i32> = units
         .iter()
@@ -23,9 +27,19 @@ pub fn resolve_movement_pure(units: &[UnitSnapshot]) -> CombatDeltas {
         .map(|u| (u.entity, u.hp))
         .collect();
     let by_entity: HashMap<Entity, &UnitSnapshot> = units.iter().map(|u| (u.entity, u)).collect();
+    let initial_city_hps: HashMap<Entity, i32> = cities
+        .iter()
+        .map(|city| (city.entity, city.hp.max(0)))
+        .collect();
+    let mut city_hps = initial_city_hps.clone();
+    let mut city_owners: HashMap<Entity, Entity> = cities
+        .iter()
+        .map(|city| (city.entity, city.owner))
+        .collect();
     let mut positions: HashMap<Entity, HexPosition> = HashMap::new();
     let mut hps: HashMap<Entity, i32> = HashMap::new();
     let mut deaths: HashSet<Entity> = HashSet::new();
+    let mut city_captures = Vec::new();
 
     for u in units {
         if u.hp <= 0 {
@@ -54,6 +68,17 @@ pub fn resolve_movement_pure(units: &[UnitSnapshot]) -> CombatDeltas {
         // 0 or 1 alive: tile is already settled; sole survivor (if any) stays at the conflict tile.
     }
 
+    resolve_city_melee(
+        units,
+        cities,
+        &mut positions,
+        &deaths,
+        &mut city_hps,
+        &mut city_owners,
+        city_capture_hp,
+        &mut city_captures,
+    );
+
     let hp_changes: HashMap<Entity, i32> = hps
         .iter()
         .filter_map(|(e, &h)| {
@@ -62,11 +87,75 @@ pub fn resolve_movement_pure(units: &[UnitSnapshot]) -> CombatDeltas {
             if delta != 0 { Some((*e, delta)) } else { None }
         })
         .collect();
+    let city_hp_changes: HashMap<Entity, i32> = city_hps
+        .iter()
+        .filter_map(|(e, &h)| {
+            let initial = initial_city_hps.get(e).copied().unwrap_or(0);
+            let delta = h - initial;
+            if delta != 0 { Some((*e, delta)) } else { None }
+        })
+        .collect();
 
     CombatDeltas {
         hp_changes,
+        city_hp_changes,
+        city_captures,
         final_positions: positions,
         deaths,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_city_melee(
+    units: &[UnitSnapshot],
+    cities: &[CitySnapshot],
+    positions: &mut HashMap<Entity, HexPosition>,
+    deaths: &HashSet<Entity>,
+    city_hps: &mut HashMap<Entity, i32>,
+    city_owners: &mut HashMap<Entity, Entity>,
+    city_capture_hp: u32,
+    city_captures: &mut Vec<CityCapture>,
+) {
+    let mut attackers: Vec<_> = units
+        .iter()
+        .filter(|unit| unit.hp > 0)
+        .filter(|unit| !deaths.contains(&unit.entity))
+        .filter(|unit| unit.attack_range == 1)
+        .filter_map(|unit| {
+            let ResolveAction::MoveTo(target) = unit.action else {
+                return None;
+            };
+            if positions.get(&unit.entity).copied() != Some(target) {
+                return None;
+            }
+            Some((unit.entity, unit, target))
+        })
+        .collect();
+    attackers.sort_by_key(|(entity, _, _)| *entity);
+
+    for (unit_entity, unit, target) in attackers {
+        let Some(city) = cities.iter().find(|city| city.pos == target) else {
+            continue;
+        };
+        if city_owners.get(&city.entity).copied() == Some(unit.owner) {
+            continue;
+        }
+
+        let city_hp = city_hps.entry(city.entity).or_insert(0);
+        let before = *city_hp;
+        *city_hp = city_hp.saturating_sub(unit.attack_damage as i32);
+
+        if before <= 0 || *city_hp <= 0 {
+            city_owners.insert(city.entity, unit.owner);
+            *city_hp = (city_capture_hp.min(city.max_hp)) as i32;
+            city_captures.push(CityCapture {
+                city: city.entity,
+                by_unit: unit_entity,
+                new_owner: unit.owner,
+            });
+        } else {
+            positions.insert(unit.entity, unit.start_pos);
+        }
     }
 }
 
@@ -150,7 +239,7 @@ mod tests {
 
     #[test]
     fn empty_input_returns_empty_deltas() {
-        let deltas = resolve_movement_pure(&[]);
+        let deltas = resolve_movement_pure(&[], &[], 10);
         assert!(deltas.hp_changes.is_empty());
         assert!(deltas.final_positions.is_empty());
         assert!(deltas.deaths.is_empty());
@@ -185,7 +274,7 @@ mod tests {
             },
         ];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         // Both alive → both rolled back to start. A back to (0,0), B stays at (1,0).
         assert_eq!(
@@ -232,7 +321,7 @@ mod tests {
             },
         ];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         assert!(deltas.deaths.contains(&entities[1]), "B should be dead");
         assert!(!deltas.deaths.contains(&entities[0]), "A should be alive");
@@ -273,7 +362,7 @@ mod tests {
             },
         ];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         assert!(deltas.deaths.contains(&entities[0]));
         assert!(deltas.deaths.contains(&entities[1]));
@@ -318,7 +407,7 @@ mod tests {
             },
         ];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         // Each took 8 damage from the other two.
         assert_eq!(deltas.hp_changes.get(&entities[0]), Some(&-8));
@@ -387,7 +476,7 @@ mod tests {
             },
         ];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         assert_eq!(deltas.final_positions.get(&entities[0]), Some(&t1));
         assert_eq!(deltas.final_positions.get(&entities[1]), Some(&t2));
@@ -442,7 +531,7 @@ mod tests {
             },
         ];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         // No conflict ever forms; both units end up at their destinations.
         assert_eq!(deltas.final_positions.get(&entities[0]), Some(&t2));
@@ -466,7 +555,7 @@ mod tests {
             action: ResolveAction::MoveTo(HexPosition::new(1, 0)),
         }];
 
-        let deltas = resolve_movement_pure(&snapshot);
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
 
         assert_eq!(
             deltas.final_positions.get(&entities[0]),
@@ -477,5 +566,109 @@ mod tests {
             "no damage in a non-conflict move"
         );
         assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn melee_city_attack_captures_and_keeps_unit_on_city() {
+        let (_world, entities) = fake_entities(2);
+        let attacker_owner = entities[0];
+        let defender_owner = entities[1];
+        let city = Entity::PLACEHOLDER;
+        let city_pos = HexPosition::new(1, 0);
+        let snapshot = vec![UnitSnapshot {
+            entity: entities[0],
+            owner: attacker_owner,
+            hp: 10,
+            max_hp: 10,
+            attack_damage: 4,
+            attack_range: 1,
+            start_pos: HexPosition::new(0, 0),
+            action: ResolveAction::MoveTo(city_pos),
+        }];
+        let cities = vec![CitySnapshot {
+            entity: city,
+            owner: defender_owner,
+            hp: 3,
+            max_hp: 20,
+            pos: city_pos,
+        }];
+
+        let deltas = resolve_movement_pure(&snapshot, &cities, 10);
+
+        assert_eq!(deltas.final_positions.get(&entities[0]), Some(&city_pos));
+        assert_eq!(deltas.city_hp_changes.get(&city), Some(&7));
+        assert_eq!(
+            deltas.city_captures,
+            vec![CityCapture {
+                city,
+                by_unit: entities[0],
+                new_owner: attacker_owner,
+            }]
+        );
+    }
+
+    #[test]
+    fn melee_city_attack_rolls_back_when_city_survives() {
+        let (_world, entities) = fake_entities(2);
+        let attacker_owner = entities[0];
+        let defender_owner = entities[1];
+        let city = Entity::PLACEHOLDER;
+        let start = HexPosition::new(0, 0);
+        let city_pos = HexPosition::new(1, 0);
+        let snapshot = vec![UnitSnapshot {
+            entity: entities[0],
+            owner: attacker_owner,
+            hp: 10,
+            max_hp: 10,
+            attack_damage: 4,
+            attack_range: 1,
+            start_pos: start,
+            action: ResolveAction::MoveTo(city_pos),
+        }];
+        let cities = vec![CitySnapshot {
+            entity: city,
+            owner: defender_owner,
+            hp: 8,
+            max_hp: 20,
+            pos: city_pos,
+        }];
+
+        let deltas = resolve_movement_pure(&snapshot, &cities, 10);
+
+        assert_eq!(deltas.final_positions.get(&entities[0]), Some(&start));
+        assert_eq!(deltas.city_hp_changes.get(&city), Some(&-4));
+        assert!(deltas.city_captures.is_empty());
+    }
+
+    #[test]
+    fn ranged_unit_moving_to_city_does_not_melee_capture() {
+        let (_world, entities) = fake_entities(2);
+        let attacker_owner = entities[0];
+        let defender_owner = entities[1];
+        let city = Entity::PLACEHOLDER;
+        let city_pos = HexPosition::new(1, 0);
+        let snapshot = vec![UnitSnapshot {
+            entity: entities[0],
+            owner: attacker_owner,
+            hp: 10,
+            max_hp: 10,
+            attack_damage: 20,
+            attack_range: 2,
+            start_pos: HexPosition::new(0, 0),
+            action: ResolveAction::MoveTo(city_pos),
+        }];
+        let cities = vec![CitySnapshot {
+            entity: city,
+            owner: defender_owner,
+            hp: 1,
+            max_hp: 20,
+            pos: city_pos,
+        }];
+
+        let deltas = resolve_movement_pure(&snapshot, &cities, 10);
+
+        assert_eq!(deltas.final_positions.get(&entities[0]), Some(&city_pos));
+        assert!(deltas.city_hp_changes.is_empty());
+        assert!(deltas.city_captures.is_empty());
     }
 }

--- a/server/src/combat/systems.rs
+++ b/server/src/combat/systems.rs
@@ -1,11 +1,15 @@
 use bevy::prelude::*;
+use shared::cities::{City, CityOwner};
 use shared::hex::HexPosition;
+use shared::tiles::{OwnedTiles, TileOwner};
 use shared::unit_definition::UnitRegistry;
-use shared::units::{AttackTarget, Health, MoveTo, Owner, Unit};
+use shared::units::{AttackTarget, ColorIndex, Health, MoveTo, Owner, Unit};
 use std::collections::HashMap;
 
+use crate::cities::CITY_CAPTURE_HP;
+
 use super::algorithm::resolve_movement_pure;
-use super::types::{ResolveAction, UnitSnapshot};
+use super::types::{CitySnapshot, ResolveAction, UnitSnapshot};
 
 /// Pre-movement phase: each ranged unit with an AttackTarget hits the live unit
 /// at the target tile (if any) for `attack_damage`, with no counter and no movement.
@@ -13,18 +17,19 @@ use super::types::{ResolveAction, UnitSnapshot};
 /// a missing target here means concentrated-fire killed it earlier in this loop,
 /// or the marker survived a target despawn — either way the attack is wasted.
 pub fn resolve_ranged_attacks(
-    attackers: Query<(Entity, &Unit, &AttackTarget)>,
+    attackers: Query<(Entity, &Unit, &Owner, &AttackTarget)>,
     // Health excluded here to avoid conflicting borrows with hp_q below;
     // liveness is checked via hp_q after we find the candidate by position.
     unit_positions: Query<(Entity, &HexPosition), With<Unit>>,
+    city_positions: Query<(Entity, &HexPosition, &CityOwner), With<City>>,
     registry: Res<UnitRegistry>,
     mut hp_q: Query<&mut Health>,
     mut commands: Commands,
 ) {
     let mut acts: Vec<_> = attackers.iter().collect();
-    acts.sort_by_key(|(e, _, _)| *e);
+    acts.sort_by_key(|(e, _, _, _)| *e);
 
-    for (attacker_entity, unit, attack_target) in acts {
+    for (attacker_entity, unit, owner, attack_target) in acts {
         let Some(def) = registry.get(&unit.type_id) else {
             commands.entity(attacker_entity).remove::<AttackTarget>();
             continue;
@@ -38,15 +43,27 @@ pub fn resolve_ranged_attacks(
             })
             .map(|(e, _)| e);
 
-        if let Some(te) = target_entity
-            && let Ok(mut h) = hp_q.get_mut(te)
+        if let Some(target_entity) = target_entity
+            && let Ok(mut h) = hp_q.get_mut(target_entity)
         {
             let before = h.current;
             h.current = h.current.saturating_sub(def.attack_damage);
             println!(
-                "Ranged: {attacker_entity} hit {te} at {:?} for {} dmg (hp {} -> {})",
+                "Ranged: {attacker_entity} hit unit {target_entity} at {:?} for {} dmg (hp {} -> {})",
                 attack_target.pos, def.attack_damage, before, h.current
             );
+        } else if let Some((city_entity, _, _)) = city_positions
+            .iter()
+            .find(|(_, p, city_owner)| **p == attack_target.pos && city_owner.entity != owner.0)
+        {
+            if let Ok(mut h) = hp_q.get_mut(city_entity) {
+                let before = h.current;
+                h.current = h.current.saturating_sub(def.attack_damage);
+                println!(
+                    "Ranged: {attacker_entity} hit city {city_entity} at {:?} for {} dmg (hp {} -> {})",
+                    attack_target.pos, def.attack_damage, before, h.current
+                );
+            }
         } else {
             println!(
                 "Ranged: {attacker_entity} attack at {:?} wasted (no live target)",
@@ -79,8 +96,17 @@ pub fn resolve_movement(
         // p1: mutable HP write-back
         Query<&mut Health>,
         // p2: mutable position write-back
-        Query<&mut HexPosition>,
+        Query<&mut HexPosition, With<Unit>>,
+        // p3: city snapshot query
+        Query<(Entity, &CityOwner, &HexPosition, &Health), With<City>>,
+        // p4: city color write-back
+        Query<&mut ColorIndex, (With<City>, Without<Unit>)>,
+        // p5: unit color lookup for captured city color
+        Query<&ColorIndex, (With<Unit>, Without<City>)>,
+        // p6: city-owned tile relationship lookup
+        Query<&OwnedTiles, With<City>>,
     )>,
+    tile_owners: Query<&TileOwner>,
     registry: Res<UnitRegistry>,
     mut commands: Commands,
 ) {
@@ -107,13 +133,24 @@ pub fn resolve_movement(
             })
         })
         .collect();
+    let city_snapshot: Vec<CitySnapshot> = queries
+        .p3()
+        .iter()
+        .map(|(entity, owner, pos, health)| CitySnapshot {
+            entity,
+            owner: owner.entity,
+            hp: health.current as i32,
+            max_hp: health.max,
+            pos: *pos,
+        })
+        .collect();
 
     // Index for log-time lookup of a unit's pre-resolution state.
     let snap_by_entity: HashMap<Entity, &UnitSnapshot> =
         snapshot.iter().map(|s| (s.entity, s)).collect();
 
     // 2. Run pure algorithm.
-    let deltas = resolve_movement_pure(&snapshot);
+    let deltas = resolve_movement_pure(&snapshot, &city_snapshot, CITY_CAPTURE_HP);
 
     // 3. Apply HP changes via p1.
     for (e, delta) in &deltas.hp_changes {
@@ -124,6 +161,45 @@ pub fn resolve_movement(
                 -delta, h.current, new_hp
             );
             h.current = new_hp as u32;
+        }
+    }
+    for (e, delta) in &deltas.city_hp_changes {
+        if let Ok(mut h) = queries.p1().get_mut(*e) {
+            let new_hp = (h.current as i32 + delta).max(0);
+            println!(
+                "City combat: {e} hp {} -> {} (delta {})",
+                h.current, new_hp, delta
+            );
+            h.current = new_hp as u32;
+        }
+    }
+
+    for capture in &deltas.city_captures {
+        println!(
+            "City captured: {} by player {}",
+            capture.city, capture.new_owner
+        );
+        commands.entity(capture.city).insert(CityOwner {
+            entity: capture.new_owner,
+        });
+
+        if let Ok(unit_color) = queries.p5().get(capture.by_unit) {
+            let new_color = unit_color.0;
+            if let Ok(mut city_color) = queries.p4().get_mut(capture.city) {
+                city_color.0 = new_color;
+            }
+        }
+
+        if let Ok(owned_tiles) = queries.p6().get(capture.city) {
+            for tile_entity in owned_tiles.collection() {
+                let Ok(tile_owner) = tile_owners.get(*tile_entity) else {
+                    continue;
+                };
+                commands.entity(*tile_entity).insert(TileOwner {
+                    city_entity: tile_owner.city_entity,
+                    player_entity: Some(capture.new_owner),
+                });
+            }
         }
     }
 
@@ -471,6 +547,471 @@ mod tests {
         );
         // AttackTarget consumed.
         assert!(app.world().get::<AttackTarget>(attacker).is_none());
+    }
+
+    #[test]
+    fn resolve_ranged_attacks_city_reaches_zero_without_capture() {
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_ranged_attacks);
+
+        let archer_id = UnitTypeId(0);
+        let archer_def = UnitDefinition {
+            hp: 8,
+            move_budget: 2,
+            attack_range: 2,
+            attack_damage: 3,
+            gold_upkeep: 1,
+            production_cost: 25,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("archer".into(), archer_id);
+        registry.definitions.insert(archer_id, archer_def);
+        app.insert_resource(registry);
+
+        let (attacker, city, defender) = {
+            let world = app.world_mut();
+            let attacker_owner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let defender = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            let attacker = world
+                .spawn((
+                    Unit { type_id: archer_id },
+                    HexPosition::new(0, 0),
+                    Owner(attacker_owner),
+                    Health::full(8),
+                    AttackTarget {
+                        pos: HexPosition::new(2, 0),
+                    },
+                ))
+                .id();
+            let city = world
+                .spawn((
+                    City,
+                    HexPosition::new(2, 0),
+                    CityOwner { entity: defender },
+                    ColorIndex(1),
+                    Health {
+                        current: 3,
+                        max: 20,
+                    },
+                ))
+                .id();
+            (attacker, city, defender)
+        };
+
+        app.update();
+
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 0);
+        assert_eq!(
+            app.world().get::<CityOwner>(city).unwrap().entity,
+            defender,
+            "ranged attacks must not capture cities"
+        );
+        assert!(app.world().get::<AttackTarget>(attacker).is_none());
+    }
+
+    #[test]
+    fn resolve_city_melee_attacks_captures_and_updates_owned_tiles() {
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_movement);
+
+        let warrior_id = UnitTypeId(0);
+        let warrior_def = UnitDefinition {
+            hp: 10,
+            move_budget: 2,
+            attack_range: 1,
+            attack_damage: 4,
+            gold_upkeep: 1,
+            production_cost: 10,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("warrior".into(), warrior_id);
+        registry.definitions.insert(warrior_id, warrior_def);
+        app.insert_resource(registry);
+
+        let (city, attacker_owner, tile) = {
+            let world = app.world_mut();
+            let attacker_owner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let defender_owner = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            world.spawn((
+                Unit {
+                    type_id: warrior_id,
+                },
+                HexPosition::new(0, 0),
+                Owner(attacker_owner),
+                ColorIndex(0),
+                Health::full(10),
+                MoveTo {
+                    pos: HexPosition::new(1, 0),
+                },
+            ));
+            let city = world
+                .spawn((
+                    City,
+                    HexPosition::new(1, 0),
+                    CityOwner {
+                        entity: defender_owner,
+                    },
+                    ColorIndex(1),
+                    Health {
+                        current: 3,
+                        max: 20,
+                    },
+                ))
+                .id();
+            let tile = world
+                .spawn(TileOwner {
+                    city_entity: city,
+                    player_entity: Some(defender_owner),
+                })
+                .id();
+            (city, attacker_owner, tile)
+        };
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<CityOwner>(city).unwrap().entity,
+            attacker_owner
+        );
+        assert_eq!(app.world().get::<ColorIndex>(city).unwrap().0, 0);
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 10);
+        let tile_owner = app.world().get::<TileOwner>(tile).unwrap();
+        assert_eq!(tile_owner.city_entity, city);
+        assert_eq!(tile_owner.player_entity, Some(attacker_owner));
+    }
+
+    #[test]
+    fn resolve_city_melee_attacks_captures_city_already_at_zero() {
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_movement);
+
+        let warrior_id = UnitTypeId(0);
+        let warrior_def = UnitDefinition {
+            hp: 10,
+            move_budget: 2,
+            attack_range: 1,
+            attack_damage: 4,
+            gold_upkeep: 1,
+            production_cost: 10,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("warrior".into(), warrior_id);
+        registry.definitions.insert(warrior_id, warrior_def);
+        app.insert_resource(registry);
+
+        let (city, attacker_owner) = {
+            let world = app.world_mut();
+            let attacker_owner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let defender_owner = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            world.spawn((
+                Unit {
+                    type_id: warrior_id,
+                },
+                HexPosition::new(0, 0),
+                Owner(attacker_owner),
+                ColorIndex(0),
+                Health::full(10),
+                MoveTo {
+                    pos: HexPosition::new(1, 0),
+                },
+            ));
+            let city = world
+                .spawn((
+                    City,
+                    HexPosition::new(1, 0),
+                    CityOwner {
+                        entity: defender_owner,
+                    },
+                    ColorIndex(1),
+                    Health {
+                        current: 0,
+                        max: 20,
+                    },
+                ))
+                .id();
+            (city, attacker_owner)
+        };
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<CityOwner>(city).unwrap().entity,
+            attacker_owner
+        );
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 10);
+    }
+
+    #[test]
+    fn resolve_city_melee_attacks_damages_without_capture_when_hp_remains() {
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_movement);
+
+        let warrior_id = UnitTypeId(0);
+        let warrior_def = UnitDefinition {
+            hp: 10,
+            move_budget: 2,
+            attack_range: 1,
+            attack_damage: 4,
+            gold_upkeep: 1,
+            production_cost: 10,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("warrior".into(), warrior_id);
+        registry.definitions.insert(warrior_id, warrior_def);
+        app.insert_resource(registry);
+
+        let (city, defender_owner) = {
+            let world = app.world_mut();
+            let attacker_owner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let defender_owner = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            world.spawn((
+                Unit {
+                    type_id: warrior_id,
+                },
+                HexPosition::new(0, 0),
+                Owner(attacker_owner),
+                ColorIndex(0),
+                Health::full(10),
+                MoveTo {
+                    pos: HexPosition::new(1, 0),
+                },
+            ));
+            let city = world
+                .spawn((
+                    City,
+                    HexPosition::new(1, 0),
+                    CityOwner {
+                        entity: defender_owner,
+                    },
+                    ColorIndex(1),
+                    Health {
+                        current: 8,
+                        max: 20,
+                    },
+                ))
+                .id();
+            (city, defender_owner)
+        };
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<CityOwner>(city).unwrap().entity,
+            defender_owner
+        );
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 4);
+    }
+
+    #[test]
+    fn resolve_city_melee_attacks_rolls_back_failed_city_entry() {
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_movement);
+
+        let warrior_id = UnitTypeId(0);
+        let warrior_def = UnitDefinition {
+            hp: 10,
+            move_budget: 2,
+            attack_range: 1,
+            attack_damage: 4,
+            gold_upkeep: 1,
+            production_cost: 10,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("warrior".into(), warrior_id);
+        registry.definitions.insert(warrior_id, warrior_def);
+        app.insert_resource(registry);
+
+        let (attacker, city, defender_owner) = {
+            let world = app.world_mut();
+            let attacker_owner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let defender_owner = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            let attacker = world
+                .spawn((
+                    Unit {
+                        type_id: warrior_id,
+                    },
+                    HexPosition::new(0, 0),
+                    Owner(attacker_owner),
+                    ColorIndex(0),
+                    Health::full(10),
+                    MoveTo {
+                        pos: HexPosition::new(1, 0),
+                    },
+                ))
+                .id();
+            let city = world
+                .spawn((
+                    City,
+                    HexPosition::new(1, 0),
+                    CityOwner {
+                        entity: defender_owner,
+                    },
+                    ColorIndex(1),
+                    Health {
+                        current: 8,
+                        max: 20,
+                    },
+                ))
+                .id();
+            (attacker, city, defender_owner)
+        };
+
+        app.update();
+
+        assert_eq!(
+            *app.world().get::<HexPosition>(attacker).unwrap(),
+            HexPosition::new(0, 0),
+            "failed city assault should leave attacker outside the city"
+        );
+        assert_eq!(
+            app.world().get::<CityOwner>(city).unwrap().entity,
+            defender_owner
+        );
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 4);
+        assert!(app.world().get::<MoveTo>(attacker).is_none());
+    }
+
+    #[test]
+    fn resolve_city_melee_attacks_ignores_ranged_unit_on_city() {
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_movement);
+
+        let archer_id = UnitTypeId(0);
+        let archer_def = UnitDefinition {
+            hp: 8,
+            move_budget: 2,
+            attack_range: 2,
+            attack_damage: 12,
+            gold_upkeep: 1,
+            production_cost: 25,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("archer".into(), archer_id);
+        registry.definitions.insert(archer_id, archer_def);
+        app.insert_resource(registry);
+
+        let (city, defender_owner) = {
+            let world = app.world_mut();
+            let attacker_owner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let defender_owner = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            world.spawn((
+                Unit { type_id: archer_id },
+                HexPosition::new(0, 0),
+                Owner(attacker_owner),
+                ColorIndex(0),
+                Health::full(8),
+                MoveTo {
+                    pos: HexPosition::new(1, 0),
+                },
+            ));
+            let city = world
+                .spawn((
+                    City,
+                    HexPosition::new(1, 0),
+                    CityOwner {
+                        entity: defender_owner,
+                    },
+                    ColorIndex(1),
+                    Health {
+                        current: 5,
+                        max: 20,
+                    },
+                ))
+                .id();
+            (city, defender_owner)
+        };
+
+        app.update();
+
+        assert_eq!(
+            app.world().get::<CityOwner>(city).unwrap().entity,
+            defender_owner
+        );
+        assert_eq!(app.world().get::<Health>(city).unwrap().current, 5);
     }
 
     #[test]

--- a/server/src/combat/systems.rs
+++ b/server/src/combat/systems.rs
@@ -6,7 +6,7 @@ use shared::unit_definition::UnitRegistry;
 use shared::units::{AttackTarget, ColorIndex, Health, MoveTo, Owner, Unit};
 use std::collections::HashMap;
 
-use crate::cities::CITY_CAPTURE_HP;
+use crate::cities::{CITY_CAPTURE_HP, CityAttackedThisTurn};
 
 use super::algorithm::resolve_movement_pure;
 use super::types::{CitySnapshot, ResolveAction, UnitSnapshot};
@@ -59,6 +59,7 @@ pub fn resolve_ranged_attacks(
             if let Ok(mut h) = hp_q.get_mut(city_entity) {
                 let before = h.current;
                 h.current = h.current.saturating_sub(def.attack_damage);
+                commands.entity(city_entity).insert(CityAttackedThisTurn);
                 println!(
                     "Ranged: {attacker_entity} hit city {city_entity} at {:?} for {} dmg (hp {} -> {})",
                     attack_target.pos, def.attack_damage, before, h.current
@@ -171,6 +172,7 @@ pub fn resolve_movement(
                 h.current, new_hp, delta
             );
             h.current = new_hp as u32;
+            commands.entity(*e).insert(CityAttackedThisTurn);
         }
     }
 

--- a/server/src/combat/systems.rs
+++ b/server/src/combat/systems.rs
@@ -569,14 +569,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let defender = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             let attacker = world
@@ -643,14 +641,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let defender_owner = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             world.spawn((
@@ -728,14 +724,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let defender_owner = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             world.spawn((
@@ -803,14 +797,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let defender_owner = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             world.spawn((
@@ -878,14 +870,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let defender_owner = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             let attacker = world
@@ -961,14 +951,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let defender_owner = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             world.spawn((

--- a/server/src/combat/types.rs
+++ b/server/src/combat/types.rs
@@ -26,6 +26,17 @@ pub struct UnitSnapshot {
     pub action: ResolveAction,
 }
 
+/// One row per city, gathered by the wrapper before combat resolution.
+#[derive(Clone, Debug)]
+pub struct CitySnapshot {
+    pub entity: Entity,
+    pub owner: Entity,
+    pub hp: i32,
+    #[allow(dead_code)]
+    pub max_hp: u32,
+    pub pos: HexPosition,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResolveAction {
     /// No movement this turn.
@@ -34,9 +45,18 @@ pub enum ResolveAction {
     MoveTo(HexPosition),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CityCapture {
+    pub city: Entity,
+    pub by_unit: Entity,
+    pub new_owner: Entity,
+}
+
 #[derive(Default, Debug)]
 pub struct CombatDeltas {
     pub hp_changes: HashMap<Entity, i32>,
+    pub city_hp_changes: HashMap<Entity, i32>,
+    pub city_captures: Vec<CityCapture>,
     pub final_positions: HashMap<Entity, HexPosition>,
     pub deaths: HashSet<Entity>,
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -74,6 +74,7 @@ fn main() {
                     resolve_ranged_attacks,
                     resolve_movement,
                     cleanup_dead_units,
+                    regenerate_unattacked_cities,
                     resolve_fortify,
                     resolve_skip,
                     resolve_builds,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -77,6 +77,7 @@ fn main() {
                     resolve_fortify,
                     resolve_skip,
                     resolve_builds,
+                    eliminate_defeated_players,
                     advance_city_production,
                     advance_turn,
                 )

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
-use shared::cities::City;
+use shared::cities::{City, CityOwner};
 use shared::events::StartGame;
 use shared::events::*;
 use shared::unit_definition::{UnitRegistry, is_within_move_range};
@@ -145,6 +145,7 @@ pub fn handle_unit_action(
     player_map: Res<PlayerMap>,
     units: Query<(&HexPosition, &Owner, &Unit)>,
     enemy_units: Query<(&HexPosition, &Owner), With<Unit>>,
+    cities: Query<(&HexPosition, &CityOwner), With<City>>,
     queued_moves: Query<(Entity, &MoveTo, &Owner), With<Unit>>, // for same-turn collision detection
     turn_state: Query<&TurnState>,
     registry: Res<UnitRegistry>,
@@ -204,6 +205,13 @@ pub fn handle_unit_action(
                 println!("Rejected move: friendly already on tile");
                 return;
             }
+            if let Some((_, city_owner)) = cities.iter().find(|(p, _)| *p == target)
+                && city_owner.entity != *player_entity
+                && def.attack_range != 1
+            {
+                println!("Rejected move: only melee units can attack cities by moving");
+                return;
+            }
             // Reject if another friendly already queued a Move to the same tile this turn.
             // Skip the issuing unit's own marker — re-submitting the same target on the
             // same unit must succeed (it's a no-op replace handled by queue_marker).
@@ -224,7 +232,10 @@ pub fn handle_unit_action(
             }
             let enemy_here = enemy_units
                 .iter()
-                .any(|(p, o)| p == target && o.0 != *player_entity);
+                .any(|(p, o)| p == target && o.0 != *player_entity)
+                || cities
+                    .iter()
+                    .any(|(p, owner)| p == target && owner.entity != *player_entity);
             if !enemy_here {
                 println!("Rejected attack: no enemy at target");
                 return;
@@ -342,7 +353,7 @@ mod tests {
     use bevy::app::ScheduleRunnerPlugin;
     use bevy::state::app::StatesPlugin;
     use bevy_replicon::prelude::*;
-    use shared::cities::City;
+    use shared::cities::{City, CityOwner};
     use shared::components::*;
     use shared::events::*;
     use shared::unit_definition::*;
@@ -992,6 +1003,187 @@ mod tests {
             "Move to friendly-occupied tile must be rejected"
         );
         let _ = (player, blocker);
+    }
+
+    #[test]
+    fn test_handle_unit_action_rejects_friendly_city_targets() {
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins.set(ScheduleRunnerPlugin::run_once()),
+            StatesPlugin,
+            RepliconPlugins,
+        ));
+
+        let archer_type = UnitTypeId(0);
+        let archer_def = UnitDefinition {
+            hp: 8,
+            move_budget: 2,
+            attack_range: 2,
+            attack_damage: 3,
+            gold_upkeep: 1,
+            production_cost: 25,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("archer".into(), archer_type);
+        registry.definitions.insert(archer_type, archer_def);
+
+        app.insert_resource(registry);
+        app.init_resource::<PlayerState>();
+        app.init_resource::<PlayerMap>();
+        app.add_observer(handle_unit_action);
+        app.update();
+
+        let (client, unit) = {
+            let world = app.world_mut();
+            world.spawn(TurnState {
+                phase: TurnPhase::Accepting,
+                turn_number: 1,
+            });
+            let player = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(client, player);
+            let unit = world
+                .spawn((
+                    Unit {
+                        type_id: archer_type,
+                    },
+                    HexPosition::new(0, 0),
+                    Owner(player),
+                ))
+                .id();
+            world.spawn((City, HexPosition::new(1, 0), CityOwner { entity: player }));
+            (client, unit)
+        };
+
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(client),
+            message: UnitActionEvent {
+                unit,
+                action: UnitAction::Move {
+                    target: HexPosition::new(1, 0),
+                },
+            },
+        });
+        app.world_mut().flush();
+        assert!(
+            app.world().get::<MoveTo>(unit).is_some(),
+            "moving into a friendly city must be allowed"
+        );
+
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(client),
+            message: UnitActionEvent {
+                unit,
+                action: UnitAction::Attack {
+                    target: HexPosition::new(1, 0),
+                },
+            },
+        });
+        app.world_mut().flush();
+        assert!(
+            app.world().get::<MoveTo>(unit).is_some(),
+            "rejected attack must preserve the queued friendly-city move"
+        );
+        assert!(
+            app.world().get::<AttackTarget>(unit).is_none(),
+            "attacking a friendly city must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_handle_unit_action_rejects_ranged_move_to_enemy_city() {
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins.set(ScheduleRunnerPlugin::run_once()),
+            StatesPlugin,
+            RepliconPlugins,
+        ));
+
+        let archer_type = UnitTypeId(0);
+        let archer_def = UnitDefinition {
+            hp: 8,
+            move_budget: 2,
+            attack_range: 2,
+            attack_damage: 3,
+            gold_upkeep: 1,
+            production_cost: 25,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("archer".into(), archer_type);
+        registry.definitions.insert(archer_type, archer_def);
+
+        app.insert_resource(registry);
+        app.init_resource::<PlayerState>();
+        app.init_resource::<PlayerMap>();
+        app.add_observer(handle_unit_action);
+        app.update();
+
+        let (client, unit) = {
+            let world = app.world_mut();
+            world.spawn(TurnState {
+                phase: TurnPhase::Accepting,
+                turn_number: 1,
+            });
+            let player = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                    slot_index: 0,
+                })
+                .id();
+            let enemy = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                    slot_index: 1,
+                })
+                .id();
+            let client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(client, player);
+            let unit = world
+                .spawn((
+                    Unit {
+                        type_id: archer_type,
+                    },
+                    HexPosition::new(0, 0),
+                    Owner(player),
+                ))
+                .id();
+            world.spawn((City, HexPosition::new(1, 0), CityOwner { entity: enemy }));
+            (client, unit)
+        };
+
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(client),
+            message: UnitActionEvent {
+                unit,
+                action: UnitAction::Move {
+                    target: HexPosition::new(1, 0),
+                },
+            },
+        });
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get::<MoveTo>(unit).is_none(),
+            "ranged units must not capture cities by moving into them"
+        );
     }
 
     #[test]

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -31,7 +31,10 @@ pub struct PlayerState {
     pub finished_cnt: i32,
 }
 
-pub fn update_turn_phase(players: Query<(), With<Player>>, mut turn_state: Query<&mut TurnState>) {
+pub fn update_turn_phase(
+    players: Query<(), (With<Player>, Without<DefeatedPlayer>)>,
+    mut turn_state: Query<&mut TurnState>,
+) {
     let count = players.iter().count();
     let Ok(mut state) = turn_state.single_mut() else {
         return;
@@ -73,7 +76,8 @@ pub fn handle_start_game(
     trigger: On<FromClient<StartGame>>,
     player_map: Res<PlayerMap>,
     hosts: Query<(), With<Host>>,
-    players: Query<(), With<Player>>,
+    players: Query<(), (With<Player>, Without<DefeatedPlayer>)>,
+    defeated: Query<(), With<DefeatedPlayer>>,
     mut turn_state: Query<&mut TurnState>,
 ) {
     let Ok(mut state) = turn_state.single_mut() else {
@@ -95,6 +99,10 @@ pub fn handle_start_game(
         println!("Rejected StartGame: sender is not the host");
         return;
     }
+    if defeated.contains(player_entity) {
+        println!("Rejected StartGame: sender is defeated");
+        return;
+    }
     let count = players.iter().count();
     if count < 2 {
         println!("Rejected StartGame: need >= 2 players, have {count}");
@@ -112,7 +120,7 @@ pub fn handle_finish_turn(
     trigger: On<FromClient<FinishTurn>>,
     mut player_state: ResMut<PlayerState>,
     player_map: Res<PlayerMap>,
-    players: Query<(), With<Player>>,
+    players: Query<(), (With<Player>, Without<DefeatedPlayer>)>,
 ) {
     let client_entity = match trigger.client_id {
         ClientId::Client(entity) => entity,
@@ -158,6 +166,7 @@ pub fn handle_unit_action(
     queued_moves: Query<(Entity, &MoveTo, &Owner), With<Unit>>, // for same-turn collision detection
     turn_state: Query<&TurnState>,
     registry: Res<UnitRegistry>,
+    defeated: Query<(), With<DefeatedPlayer>>,
 ) {
     // common-path validation
     let Ok(state) = turn_state.single() else {
@@ -174,6 +183,9 @@ pub fn handle_unit_action(
     let Some(player_entity) = player_map.client_to_player.get(&client_entity) else {
         return;
     };
+    if defeated.contains(*player_entity) {
+        return;
+    }
 
     let entity = trigger.message.unit;
     let Ok((pos, owner, unit)) = units.get(entity) else {
@@ -326,6 +338,51 @@ pub fn resolve_builds(
     }
 }
 
+pub fn eliminate_defeated_players(
+    players: Query<Entity, (With<Player>, Without<DefeatedPlayer>)>,
+    cities: Query<&CityOwner, With<City>>,
+    units: Query<(Entity, &Owner, &Unit)>,
+    registry: Res<UnitRegistry>,
+    player_map: Res<PlayerMap>,
+    mut player_state: ResMut<PlayerState>,
+    mut commands: Commands,
+) {
+    for player_entity in &players {
+        let controls_city = cities.iter().any(|owner| owner.entity == player_entity);
+        let has_settler = units.iter().any(|(_, owner, unit)| {
+            owner.0 == player_entity
+                && registry
+                    .get(&unit.type_id)
+                    .is_some_and(|def| def.build_targets.iter().any(|target| target == "city"))
+        });
+        if controls_city || has_settler {
+            continue;
+        }
+
+        println!("Player {player_entity} defeated: no cities and no settlers");
+        commands.entity(player_entity).insert(DefeatedPlayer);
+
+        for (unit_entity, owner, _) in &units {
+            if owner.0 == player_entity {
+                commands.entity(unit_entity).despawn();
+            }
+        }
+
+        for (&client_entity, &mapped_player) in &player_map.client_to_player {
+            if mapped_player != player_entity {
+                continue;
+            }
+            if player_state
+                .turn
+                .remove(&client_entity)
+                .is_some_and(|state| state == PlayerTurnState::Finished)
+            {
+                player_state.finished_cnt -= 1;
+            }
+        }
+    }
+}
+
 pub fn advance_turn(mut turn_state: Query<&mut TurnState>, mut player_state: ResMut<PlayerState>) {
     let Ok(mut state) = turn_state.single_mut() else {
         return;
@@ -343,7 +400,7 @@ pub fn advance_turn(mut turn_state: Query<&mut TurnState>, mut player_state: Res
 pub fn turn_is_resolving(
     turn_state: Query<&TurnState>,
     player_state: Res<PlayerState>,
-    players: Query<(), With<Player>>,
+    players: Query<(), (With<Player>, Without<DefeatedPlayer>)>,
 ) -> bool {
     let Ok(state) = turn_state.single() else {
         return false;
@@ -1182,6 +1239,151 @@ mod tests {
             app.world().get::<MoveTo>(unit).is_none(),
             "ranged units must not capture cities by moving into them"
         );
+    }
+
+    #[test]
+    fn eliminate_defeated_players_marks_player_and_despawns_units() {
+        let mut app = App::new();
+        app.add_systems(Update, eliminate_defeated_players);
+
+        let warrior_type = UnitTypeId(0);
+        let mut registry = UnitRegistry::default();
+        registry.definitions.insert(
+            warrior_type,
+            UnitDefinition {
+                hp: 10,
+                move_budget: 2,
+                attack_range: 1,
+                attack_damage: 4,
+                gold_upkeep: 1,
+                production_cost: 20,
+                build_targets: vec![],
+                terrain_cost: HashMap::new(),
+            },
+        );
+        app.insert_resource(registry);
+        app.init_resource::<PlayerMap>();
+        app.init_resource::<PlayerState>();
+
+        let (player, unit, client) = {
+            let world = app.world_mut();
+            let player = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                })
+                .id();
+            let client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(client, player);
+            world
+                .resource_mut::<PlayerState>()
+                .turn
+                .insert(client, PlayerTurnState::Finished);
+            world.resource_mut::<PlayerState>().finished_cnt = 1;
+            let unit = world
+                .spawn((
+                    Unit {
+                        type_id: warrior_type,
+                    },
+                    Owner(player),
+                ))
+                .id();
+            (player, unit, client)
+        };
+
+        app.update();
+
+        assert!(app.world().get::<DefeatedPlayer>(player).is_some());
+        assert!(!app.world().entities().contains(unit));
+        assert!(
+            !app.world()
+                .resource::<PlayerState>()
+                .turn
+                .contains_key(&client)
+        );
+        assert_eq!(app.world().resource::<PlayerState>().finished_cnt, 0);
+    }
+
+    #[test]
+    fn eliminate_defeated_players_keeps_players_with_city_or_settler() {
+        let mut app = App::new();
+        app.add_systems(Update, eliminate_defeated_players);
+
+        let settler_type = UnitTypeId(0);
+        let warrior_type = UnitTypeId(1);
+        let mut registry = UnitRegistry::default();
+        registry.definitions.insert(
+            settler_type,
+            UnitDefinition {
+                hp: 5,
+                move_budget: 2,
+                attack_range: 0,
+                attack_damage: 0,
+                gold_upkeep: 0,
+                production_cost: 40,
+                build_targets: vec!["city".to_string()],
+                terrain_cost: HashMap::new(),
+            },
+        );
+        registry.definitions.insert(
+            warrior_type,
+            UnitDefinition {
+                hp: 10,
+                move_budget: 2,
+                attack_range: 1,
+                attack_damage: 4,
+                gold_upkeep: 1,
+                production_cost: 20,
+                build_targets: vec![],
+                terrain_cost: HashMap::new(),
+            },
+        );
+        app.insert_resource(registry);
+        app.init_resource::<PlayerMap>();
+        app.init_resource::<PlayerState>();
+
+        let (settler_player, city_player) = {
+            let world = app.world_mut();
+            let settler_player = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                })
+                .id();
+            let city_player = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                })
+                .id();
+            world.spawn((
+                Unit {
+                    type_id: settler_type,
+                },
+                Owner(settler_player),
+            ));
+            world.spawn((
+                Unit {
+                    type_id: warrior_type,
+                },
+                Owner(city_player),
+            ));
+            world.spawn((
+                City,
+                CityOwner {
+                    entity: city_player,
+                },
+            ));
+            (settler_player, city_player)
+        };
+
+        app.update();
+
+        assert!(app.world().get::<DefeatedPlayer>(settler_player).is_none());
+        assert!(app.world().get::<DefeatedPlayer>(city_player).is_none());
     }
 
     #[test]

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -1046,7 +1046,6 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let client = world.spawn_empty().id();
@@ -1142,14 +1141,12 @@ mod tests {
                 .spawn(Player {
                     color_index: 0,
                     gold: 0,
-                    slot_index: 0,
                 })
                 .id();
             let enemy = world
                 .spawn(Player {
                     color_index: 1,
                     gold: 0,
-                    slot_index: 1,
                 })
                 .id();
             let client = world.spawn_empty().id();

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -72,12 +72,21 @@ pub fn update_turn_phase(
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn handle_start_game(
     trigger: On<FromClient<StartGame>>,
     player_map: Res<PlayerMap>,
     hosts: Query<(), With<Host>>,
-    players: Query<(), (With<Player>, Without<DefeatedPlayer>)>,
+    players: Query<
+        (),
+        (
+            With<Player>,
+            Without<DefeatedPlayer>,
+            Without<VictoriousPlayer>,
+        ),
+    >,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
     mut turn_state: Query<&mut TurnState>,
 ) {
     let Ok(mut state) = turn_state.single_mut() else {
@@ -103,6 +112,10 @@ pub fn handle_start_game(
         println!("Rejected StartGame: sender is defeated");
         return;
     }
+    if victorious.contains(player_entity) {
+        println!("Rejected StartGame: sender is victorious");
+        return;
+    }
     let count = players.iter().count();
     if count < 2 {
         println!("Rejected StartGame: need >= 2 players, have {count}");
@@ -121,6 +134,7 @@ pub fn handle_finish_turn(
     mut player_state: ResMut<PlayerState>,
     player_map: Res<PlayerMap>,
     players: Query<(), (With<Player>, Without<DefeatedPlayer>)>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
     let client_entity = match trigger.client_id {
         ClientId::Client(entity) => entity,
@@ -131,6 +145,9 @@ pub fn handle_finish_turn(
         return;
     };
     if !players.contains(player_entity) {
+        return;
+    }
+    if victorious.contains(player_entity) {
         return;
     }
     let prev_state = player_state
@@ -167,6 +184,7 @@ pub fn handle_unit_action(
     turn_state: Query<&TurnState>,
     registry: Res<UnitRegistry>,
     defeated: Query<(), With<DefeatedPlayer>>,
+    victorious: Query<(), With<VictoriousPlayer>>,
 ) {
     // common-path validation
     let Ok(state) = turn_state.single() else {
@@ -184,6 +202,9 @@ pub fn handle_unit_action(
         return;
     };
     if defeated.contains(*player_entity) {
+        return;
+    }
+    if victorious.contains(*player_entity) {
         return;
     }
 
@@ -338,8 +359,16 @@ pub fn resolve_builds(
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn eliminate_defeated_players(
-    players: Query<Entity, (With<Player>, Without<DefeatedPlayer>)>,
+    players: Query<
+        Entity,
+        (
+            With<Player>,
+            Without<DefeatedPlayer>,
+            Without<VictoriousPlayer>,
+        ),
+    >,
     cities: Query<&CityOwner, With<City>>,
     units: Query<(Entity, &Owner, &Unit)>,
     registry: Res<UnitRegistry>,
@@ -347,6 +376,8 @@ pub fn eliminate_defeated_players(
     mut player_state: ResMut<PlayerState>,
     mut commands: Commands,
 ) {
+    let mut survivors = Vec::new();
+
     for player_entity in &players {
         let controls_city = cities.iter().any(|owner| owner.entity == player_entity);
         let has_settler = units.iter().any(|(_, owner, unit)| {
@@ -356,6 +387,7 @@ pub fn eliminate_defeated_players(
                     .is_some_and(|def| def.build_targets.iter().any(|target| target == "city"))
         });
         if controls_city || has_settler {
+            survivors.push(player_entity);
             continue;
         }
 
@@ -370,6 +402,25 @@ pub fn eliminate_defeated_players(
 
         for (&client_entity, &mapped_player) in &player_map.client_to_player {
             if mapped_player != player_entity {
+                continue;
+            }
+            if player_state
+                .turn
+                .remove(&client_entity)
+                .is_some_and(|state| state == PlayerTurnState::Finished)
+            {
+                player_state.finished_cnt -= 1;
+            }
+        }
+    }
+
+    if survivors.len() == 1 {
+        let winner = survivors[0];
+        println!("Player {winner} won: last surviving player");
+        commands.entity(winner).insert(VictoriousPlayer);
+
+        for (&client_entity, &mapped_player) in &player_map.client_to_player {
+            if mapped_player != winner {
                 continue;
             }
             if player_state
@@ -1384,6 +1435,83 @@ mod tests {
 
         assert!(app.world().get::<DefeatedPlayer>(settler_player).is_none());
         assert!(app.world().get::<DefeatedPlayer>(city_player).is_none());
+        assert!(
+            app.world()
+                .get::<VictoriousPlayer>(settler_player)
+                .is_none()
+        );
+        assert!(app.world().get::<VictoriousPlayer>(city_player).is_none());
+    }
+
+    #[test]
+    fn eliminate_defeated_players_marks_last_survivor_victorious() {
+        let mut app = App::new();
+        app.add_systems(Update, eliminate_defeated_players);
+
+        let warrior_type = UnitTypeId(0);
+        let mut registry = UnitRegistry::default();
+        registry.definitions.insert(
+            warrior_type,
+            UnitDefinition {
+                hp: 10,
+                move_budget: 2,
+                attack_range: 1,
+                attack_damage: 4,
+                gold_upkeep: 1,
+                production_cost: 20,
+                build_targets: vec![],
+                terrain_cost: HashMap::new(),
+            },
+        );
+        app.insert_resource(registry);
+        app.init_resource::<PlayerMap>();
+        app.init_resource::<PlayerState>();
+
+        let (winner, loser, winner_client) = {
+            let world = app.world_mut();
+            let winner = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                })
+                .id();
+            let loser = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                })
+                .id();
+            let winner_client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(winner_client, winner);
+            world
+                .resource_mut::<PlayerState>()
+                .turn
+                .insert(winner_client, PlayerTurnState::Finished);
+            world.resource_mut::<PlayerState>().finished_cnt = 1;
+            world.spawn((City, CityOwner { entity: winner }));
+            world.spawn((
+                Unit {
+                    type_id: warrior_type,
+                },
+                Owner(loser),
+            ));
+            (winner, loser, winner_client)
+        };
+
+        app.update();
+
+        assert!(app.world().get::<VictoriousPlayer>(winner).is_some());
+        assert!(app.world().get::<DefeatedPlayer>(loser).is_some());
+        assert!(
+            !app.world()
+                .resource::<PlayerState>()
+                .turn
+                .contains_key(&winner_client)
+        );
+        assert_eq!(app.world().resource::<PlayerState>().finished_cnt, 0);
     }
 
     #[test]

--- a/shared/src/components.rs
+++ b/shared/src/components.rs
@@ -43,6 +43,11 @@ pub struct Host;
 #[require(Replicated)]
 pub struct WaitingPlayer;
 
+/// Marker placed on players who have been eliminated from the current game.
+/// Replicated so their client can switch to a loss screen and stop interaction.
+#[derive(Component, Serialize, Deserialize, Clone, Debug)]
+pub struct DefeatedPlayer;
+
 /// Player colors for rendering. Index by Player::color_index.
 pub const PLAYER_COLORS: [Color; 8] = [
     Color::srgb(0.9, 0.2, 0.2), // red

--- a/shared/src/components.rs
+++ b/shared/src/components.rs
@@ -48,6 +48,11 @@ pub struct WaitingPlayer;
 #[derive(Component, Serialize, Deserialize, Clone, Debug)]
 pub struct DefeatedPlayer;
 
+/// Marker placed on the last surviving player in a completed game.
+/// Replicated so their client can switch to a victory screen and stop interaction.
+#[derive(Component, Serialize, Deserialize, Clone, Debug)]
+pub struct VictoriousPlayer;
+
 /// Player colors for rendering. Index by Player::color_index.
 pub const PLAYER_COLORS: [Color; 8] = [
     Color::srgb(0.9, 0.2, 0.2), // red

--- a/shared/src/plugin.rs
+++ b/shared/src/plugin.rs
@@ -19,6 +19,7 @@ impl Plugin for SharedPlugin {
             .replicate::<Player>()
             .replicate::<Host>()
             .replicate::<WaitingPlayer>()
+            .replicate::<DefeatedPlayer>()
             .replicate::<TurnState>()
             .replicate::<Unit>()
             .replicate::<Owner>()

--- a/shared/src/plugin.rs
+++ b/shared/src/plugin.rs
@@ -20,6 +20,7 @@ impl Plugin for SharedPlugin {
             .replicate::<Host>()
             .replicate::<WaitingPlayer>()
             .replicate::<DefeatedPlayer>()
+            .replicate::<VictoriousPlayer>()
             .replicate::<TurnState>()
             .replicate::<Unit>()
             .replicate::<Owner>()


### PR DESCRIPTION
## Summary

Adds city combat, capture, city HP/regen, and end-game victory/defeat states.

## Changes

- Added city HP using the existing replicated `Health` component.
- Added city health bars on the client:
  - dark blue fill
  - black background
  - rendered higher than unit health bars to avoid overlap
- Units can attack enemy cities:
  - melee units attack by moving into an enemy city tile
  - ranged units attack cities with the existing `Attack` action
  - ranged attacks can reduce city HP but cannot capture
  - melee attacks capture cities when city HP reaches zero or is already zero
- Captured cities:
  - change owner
  - update color
  - restore HP
  - keep the same owned tiles, while updating their owning player
- Failed melee city attacks roll the unit back instead of leaving it on the city tile.
- Friendly cities are valid movement destinations.
- Cities regenerate `2 HP` on turns when they were not attacked.
- Added game-over states:
  - players lose when they control no cities and no settlers
  - defeated players’ units despawn
  - last surviving player wins
  - defeated/victorious clients see full-screen end screens
  - defeated/victorious clients can no longer issue actions

## Architecture Notes

- City melee combat resolution lives in the pure combat algorithm layer.
- ECS combat systems snapshot units/cities, call the pure resolver, and apply results.
- Server remains authoritative for validation, capture, regeneration, defeat, and victory.
- New replicated markers:
  - `DefeatedPlayer`
  - `VictoriousPlayer`
- Added a non-replicated `CityAttackedThisTurn` marker for city regeneration suppression.

## Testing

Passed locally:

- `cargo fmt`
- `cargo test -p server`
- `cargo check --workspace`
- `cargo clippy --workspace`
