### PR TITLE
Distinct per-terrain tile visuals

### DIFF
--- a/client/src/visuals/hexes.rs
+++ b/client/src/visuals/hexes.rs
@@ -18,8 +18,7 @@ pub struct HexMaterials {
     pub claimed: Vec<Handle<ColorMaterial>>,
     pub valid_attack: Handle<ColorMaterial>,
     /// Base material per terrain, indexed by `terrain as usize` (see `Terrain::ALL`).
-    /// Placeholder is grass for every terrain; the per-terrain visuals work swaps
-    /// in distinct textures/colors here.
+    /// Each terrain gets a distinct, readable base (see `terrain_material`).
     pub terrain: Vec<Handle<ColorMaterial>>,
 }
 
@@ -54,10 +53,11 @@ pub fn setup_hex_materials(
             default_texture.clone(),
             Color::srgb(0.8, 0.3, 0.3),
         )),
-        // Placeholder: grass for every terrain. Per-terrain visuals replace these.
+        // Distinct base material per terrain, indexed by `terrain as usize`.
+        // Iterating `Terrain::ALL` keeps index == discriminant reorder-safe.
         terrain: Terrain::ALL
             .iter()
-            .map(|_| materials.add(hex_material(default_texture.clone(), Color::WHITE)))
+            .map(|t| materials.add(terrain_material(default_texture.clone(), *t)))
             .collect(),
     };
     commands.insert_resource(hex_materials);
@@ -80,6 +80,35 @@ pub fn spawn_hex_visuals(
             Transform::from_xyz(pixel.x, pixel.y, 0.0)
                 .with_rotation(Quat::from_rotation_z(std::f32::consts::FRAC_PI_6)),
         ));
+    }
+}
+
+/// Distinct base material for a terrain. The grass texture is green-dominant
+/// (avg ~RGB 111,147,36), so a multiplicative tint can only reach the greens:
+/// grassland is the texture untouched, hill an olive/tan, forest a darker green.
+/// Gray (mountain) and blue (water) aren't reachable by multiplying a green
+/// texture, so they're flat fills with no texture to guarantee the hue.
+fn terrain_material(texture: Handle<Image>, terrain: Terrain) -> ColorMaterial {
+    match terrain {
+        // Texture as-is: the grass png already reads as grassland.
+        Terrain::Grassland => hex_material(texture, Color::WHITE),
+        // Lift red/blue, hold green to pull the yellow-green toward olive/tan.
+        Terrain::Hill => hex_material(texture, Color::srgb(1.3, 0.95, 1.2)),
+        // Darken and bias green so it reads as a deeper forest green.
+        Terrain::Forest => hex_material(texture, Color::srgb(0.4, 0.7, 0.3)),
+        // Flat fills: a green texture can't multiply down to gray/blue.
+        Terrain::Mountain => flat_material(Color::srgb(0.5, 0.5, 0.5)),
+        Terrain::Water => flat_material(Color::srgb(0.2, 0.45, 0.85)),
+    }
+}
+
+/// Untextured solid color — used where a tint of the grass texture can't reach
+/// the target hue (mountain gray, water blue).
+fn flat_material(color: Color) -> ColorMaterial {
+    ColorMaterial {
+        color,
+        texture: None,
+        ..default()
     }
 }
 


### PR DESCRIPTION
## What

Makes the map read as terrain at a glance by giving each terrain a distinct base material, instead of the placeholder where all five terrains rendered as grass.

## How

`setup_hex_materials` now builds the `HexMaterials::terrain` Vec via a new `terrain_material` helper that picks a per-terrain look:

- **Grassland** — the grass texture untouched (it already reads as grassland).
- **Hill** — olive/tan tint of the grass texture.
- **Forest** — darker-green tint of the grass texture.
- **Mountain** — flat gray fill (no texture).
- **Water** — flat blue fill (no texture).

The grass texture is green-dominant (avg ~RGB 111,147,36), so a multiplicative tint can only reach the greens. Gray and blue aren't reachable by tinting a green texture, so mountain and water use flat untextured fills to guarantee the hue.

Materials are built by iterating `Terrain::ALL`, so the Vec index stays equal to `terrain as usize` and is reorder-safe. The highlight handles (default/hovered/valid_move/valid_attack/claimed) are unchanged.

## Scope

Single file: `client/src/visuals/hexes.rs`. No new assets. No changes to `input.rs` or anything else.

## Verification

`cargo build`, `cargo test`, `cargo clippy`, and `cargo fmt --check` all pass across the workspace. The client needs a window/GPU and can't run headless, so the on-screen colors are for visual confirmation post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)