### PR TITLE
Lobby map-config UI: host chooses map settings

### DIFF
--- a/client/src/lobby.rs
+++ b/client/src/lobby.rs
@@ -4,7 +4,8 @@ use shared::components::{
     DefeatedPlayer, Host, PLAYER_COLORS, Player, TurnPhase, TurnState, VictoriousPlayer,
     WaitingPlayer,
 };
-use shared::events::StartGame;
+use shared::events::{SetMapConfig, StartGame};
+use shared::map_settings::{MapSettings, MapSize};
 
 use crate::input::Controller;
 use crate::input::local_player_game_over;
@@ -24,6 +25,74 @@ pub struct LobbyPlayerList;
 /// Marker for lobby player rows; despawn all on rebuild.
 #[derive(Component)]
 pub struct LobbyPlayerRow;
+
+/// Host-only map-settings section; shown only to the host while in the lobby.
+#[derive(Component)]
+pub struct MapConfigSection;
+
+/// A map-size choice button (Small / Medium / Large).
+#[derive(Component)]
+pub struct MapSizeButton(pub MapSize);
+
+/// Which terrain knob a stepper button controls.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TerrainKnob {
+    Hilliness,
+    Forest,
+    Water,
+}
+
+/// Discrete terrain levels. bevy_ui has no slider widget, so each knob is a row
+/// of three Low/Med/High buttons rather than a continuous control.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TerrainLevel {
+    Low,
+    Med,
+    High,
+}
+
+impl TerrainLevel {
+    /// Normalized weight sent to the generator for this level.
+    fn value(self) -> f32 {
+        match self {
+            TerrainLevel::Low => 0.15,
+            TerrainLevel::Med => 0.3,
+            TerrainLevel::High => 0.5,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            TerrainLevel::Low => "Low",
+            TerrainLevel::Med => "Med",
+            TerrainLevel::High => "High",
+        }
+    }
+}
+
+/// Bucket a stored weight to the nearest discrete level. The default weights
+/// (e.g. water 0.2) don't equal any level exactly, and `f32 ==` is unreliable,
+/// so highlighting picks the closest level instead of an exact match.
+fn nearest_level(value: f32) -> TerrainLevel {
+    [TerrainLevel::Low, TerrainLevel::Med, TerrainLevel::High]
+        .into_iter()
+        .min_by(|a, b| {
+            (a.value() - value)
+                .abs()
+                .total_cmp(&(b.value() - value).abs())
+        })
+        .unwrap_or(TerrainLevel::Med)
+}
+
+/// A terrain-knob stepper button: sets `knob` to `level` when clicked.
+#[derive(Component)]
+pub struct TerrainLevelButton {
+    pub knob: TerrainKnob,
+    pub level: TerrainLevel,
+}
+
+const SELECTED_BG: Color = Color::linear_rgb(0.35, 0.28, 0.07); // muted gold = chosen
+const UNSELECTED_BG: Color = Color::BLACK;
 
 pub fn spawn_lobby_ui(mut commands: Commands) {
     commands
@@ -92,6 +161,8 @@ pub fn spawn_lobby_ui(mut commands: Commands) {
                     },
                 ));
 
+                spawn_map_config_section(panel);
+
                 panel
                     .spawn((
                         StartGameButton,
@@ -112,6 +183,119 @@ pub fn spawn_lobby_ui(mut commands: Commands) {
                     .with_child(Text::new("Start Game"));
             });
         });
+}
+
+/// Builds the host-only map-settings panel (size + terrain knobs). Starts hidden;
+/// `update_map_config_ui` reveals it only for the host while in the lobby.
+fn spawn_map_config_section(panel: &mut ChildSpawnerCommands) {
+    panel
+        .spawn((
+            MapConfigSection,
+            Node {
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                width: Val::Percent(100.0),
+                row_gap: Val::Px(8.0),
+                display: Display::None, // shown only to the host
+                ..default()
+            },
+        ))
+        .with_children(|section| {
+            section.spawn((
+                Text::new("Map Settings"),
+                TextFont {
+                    font_size: 18.0,
+                    ..default()
+                },
+                TextColor(Color::linear_rgb(1.0, 0.8, 0.2)),
+            ));
+
+            // Map size row.
+            spawn_config_label(section, "Size");
+            section.spawn(config_row_node()).with_children(|row| {
+                for size in [MapSize::Small, MapSize::Medium, MapSize::Large] {
+                    row.spawn((
+                        MapSizeButton(size),
+                        Button,
+                        config_button_node(),
+                        BorderColor::all(Color::linear_rgb(1.0, 0.8, 0.2)),
+                        BackgroundColor(UNSELECTED_BG),
+                    ))
+                    .with_child(Text::new(map_size_label(size)));
+                }
+            });
+
+            // One Low/Med/High stepper row per terrain knob.
+            for (knob, label) in [
+                (TerrainKnob::Hilliness, "Hills"),
+                (TerrainKnob::Forest, "Forest"),
+                (TerrainKnob::Water, "Water"),
+            ] {
+                spawn_config_label(section, label);
+                section.spawn(config_row_node()).with_children(|row| {
+                    for level in [TerrainLevel::Low, TerrainLevel::Med, TerrainLevel::High] {
+                        row.spawn((
+                            TerrainLevelButton { knob, level },
+                            Button,
+                            config_button_node(),
+                            BorderColor::all(Color::linear_rgb(1.0, 0.8, 0.2)),
+                            BackgroundColor(UNSELECTED_BG),
+                        ))
+                        .with_child(Text::new(level.label()));
+                    }
+                });
+            }
+
+            // Seed is intentionally left at None (random per game): bevy_ui has no
+            // text-entry widget, so a free-text seed field is out of scope here.
+            section.spawn((
+                Text::new("Seed: random each game"),
+                TextFont {
+                    font_size: 13.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.6, 0.6, 0.6)),
+            ));
+        });
+}
+
+fn spawn_config_label(section: &mut ChildSpawnerCommands, text: &str) {
+    section.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: 14.0,
+            ..default()
+        },
+        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+    ));
+}
+
+fn config_row_node() -> Node {
+    Node {
+        flex_direction: FlexDirection::Row,
+        justify_content: JustifyContent::Center,
+        column_gap: Val::Px(6.0),
+        ..default()
+    }
+}
+
+fn config_button_node() -> Node {
+    Node {
+        width: Val::Px(76.0),
+        height: Val::Px(32.0),
+        justify_content: JustifyContent::Center,
+        align_items: AlignItems::Center,
+        border: UiRect::all(Val::Px(2.0)),
+        ..default()
+    }
+}
+
+fn map_size_label(size: MapSize) -> &'static str {
+    match size {
+        MapSize::Small => "Small",
+        MapSize::Medium => "Medium",
+        MapSize::Large => "Large",
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -325,4 +509,107 @@ pub fn handle_start_game_click(
         return;
     }
     commands.client_trigger(StartGame);
+}
+
+/// Returns true if the local player owns the `Host` entity. Mirrors the
+/// `i_am_host` check in `update_lobby_ui`.
+fn i_am_host(controller: &Controller, hosts: &Query<Entity, With<Host>>) -> bool {
+    hosts
+        .single()
+        .ok()
+        .zip(controller.player_entity)
+        .is_some_and(|(host, mine)| host == mine)
+}
+
+/// Handles clicks on any map-config button: applies the choice to the client's
+/// pending `MapSettings` and pushes it to the server with `SetMapConfig`.
+/// Gated on host + Lobby — same authority the server re-checks in
+/// `handle_set_map_config`; this just avoids sending no-op events.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_map_config_click(
+    click: On<Pointer<Click>>,
+    mut commands: Commands,
+    size_buttons: Query<&MapSizeButton>,
+    level_buttons: Query<&TerrainLevelButton>,
+    turn_state: Query<&TurnState>,
+    controller: Res<Controller>,
+    hosts: Query<Entity, With<Host>>,
+    mut settings: ResMut<MapSettings>,
+) {
+    let Ok(state) = turn_state.single() else {
+        return;
+    };
+    if state.phase != TurnPhase::Lobby {
+        return;
+    }
+    if !i_am_host(&controller, &hosts) {
+        return;
+    }
+
+    if let Ok(MapSizeButton(size)) = size_buttons.get(click.entity) {
+        settings.size = *size;
+    } else if let Ok(TerrainLevelButton { knob, level }) = level_buttons.get(click.entity) {
+        let value = level.value();
+        match knob {
+            TerrainKnob::Hilliness => settings.hilliness = value,
+            TerrainKnob::Forest => settings.forest = value,
+            TerrainKnob::Water => settings.water = value,
+        }
+    } else {
+        return; // click landed on some other button
+    }
+
+    commands.client_trigger(SetMapConfig(*settings));
+}
+
+/// Shows the host-only map-config section while in the lobby and keeps the
+/// selected-state highlight in sync with the pending `MapSettings`.
+///
+/// Kept separate from `update_lobby_ui` on purpose: that system already juggles
+/// several disjoint `&mut Node` queries held apart by hand-maintained `Without`
+/// lists. Adding our `&mut Node` / `&mut BackgroundColor` access there would force
+/// updating all of those; a separate system lets the scheduler manage the access.
+#[allow(clippy::type_complexity)]
+pub fn update_map_config_ui(
+    turn_state: Query<&TurnState>,
+    controller: Res<Controller>,
+    hosts: Query<Entity, With<Host>>,
+    settings: Res<MapSettings>,
+    mut section_nodes: Query<&mut Node, With<MapConfigSection>>,
+    mut size_buttons: Query<(&MapSizeButton, &mut BackgroundColor), Without<TerrainLevelButton>>,
+    mut level_buttons: Query<(&TerrainLevelButton, &mut BackgroundColor), Without<MapSizeButton>>,
+) {
+    let in_lobby = turn_state
+        .single()
+        .map(|s| s.phase == TurnPhase::Lobby)
+        .unwrap_or(true);
+    let show = in_lobby && i_am_host(&controller, &hosts);
+
+    for mut node in &mut section_nodes {
+        node.display = if show { Display::Flex } else { Display::None };
+    }
+    if !show {
+        return;
+    }
+
+    // Highlight the chosen size and the nearest level for each terrain knob.
+    for (MapSizeButton(size), mut bg) in &mut size_buttons {
+        *bg = BackgroundColor(if *size == settings.size {
+            SELECTED_BG
+        } else {
+            UNSELECTED_BG
+        });
+    }
+    for (TerrainLevelButton { knob, level }, mut bg) in &mut level_buttons {
+        let current = match knob {
+            TerrainKnob::Hilliness => settings.hilliness,
+            TerrainKnob::Forest => settings.forest,
+            TerrainKnob::Water => settings.water,
+        };
+        *bg = BackgroundColor(if nearest_level(current) == *level {
+            SELECTED_BG
+        } else {
+            UNSELECTED_BG
+        });
+    }
 }

--- a/client/src/lobby.rs
+++ b/client/src/lobby.rs
@@ -593,12 +593,15 @@ pub fn update_map_config_ui(
     }
 
     // Highlight the chosen size and the nearest level for each terrain knob.
+    // Write only on an actual change so we don't trip Bevy change-detection
+    // (and a UI re-extract) every frame for buttons whose color is unchanged.
     for (MapSizeButton(size), mut bg) in &mut size_buttons {
-        *bg = BackgroundColor(if *size == settings.size {
+        let want = if *size == settings.size {
             SELECTED_BG
         } else {
             UNSELECTED_BG
-        });
+        };
+        bg.set_if_neq(BackgroundColor(want));
     }
     for (TerrainLevelButton { knob, level }, mut bg) in &mut level_buttons {
         let current = match knob {
@@ -606,10 +609,11 @@ pub fn update_map_config_ui(
             TerrainKnob::Forest => settings.forest,
             TerrainKnob::Water => settings.water,
         };
-        *bg = BackgroundColor(if nearest_level(current) == *level {
+        let want = if nearest_level(current) == *level {
             SELECTED_BG
         } else {
             UNSELECTED_BG
-        });
+        };
+        bg.set_if_neq(BackgroundColor(want));
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -17,7 +17,7 @@ use bevy_replicon_renet::{
     netcode::{ClientAuthentication, NetcodeClientTransport},
     renet::ConnectionConfig,
 };
-use shared::{assets::assets_dir, events::*, plugin::SharedPlugin};
+use shared::{assets::assets_dir, events::*, map_settings::MapSettings, plugin::SharedPlugin};
 
 use audio::*;
 use camera::*;
@@ -57,6 +57,8 @@ fn main() {
         .init_resource::<Controller>()
         .init_resource::<UiState>()
         .init_resource::<CameraZoom>()
+        // Host's pending lobby map choice; sent to the server via SetMapConfig.
+        .init_resource::<MapSettings>()
         .add_systems(
             Startup,
             (
@@ -73,6 +75,7 @@ fn main() {
         .add_observer(handle_verb_button_click)
         .add_observer(handle_production_button_click)
         .add_observer(handle_start_game_click)
+        .add_observer(handle_map_config_click)
         .add_systems(
             Update,
             (
@@ -103,6 +106,7 @@ fn main() {
                     update_action_bar,
                     update_production_bar,
                     update_lobby_ui,
+                    update_map_config_ui,
                     update_lose_screen,
                 ),
             ),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,7 @@
 mod cities;
 mod cities_systems;
 mod combat;
+mod map_config;
 mod map_gen;
 mod players;
 mod turn;
@@ -22,6 +23,7 @@ use shared::{components::*, map_settings::MapSettings, plugin::SharedPlugin};
 use cities::*;
 use cities_systems::*;
 use combat::{cleanup_dead_units, resolve_movement, resolve_ranged_attacks};
+use map_config::handle_set_map_config;
 use map_gen::{
     MapTiles, cleanup_map_on_lobby, generate_map_on_start, should_cleanup_map, should_generate_map,
 };
@@ -61,6 +63,7 @@ fn main() {
         .add_observer(handle_city_action)
         .add_observer(handle_finish_turn)
         .add_observer(handle_start_game)
+        .add_observer(handle_set_map_config)
         .add_observer(claim_city_tiles)
         .add_observer(complete_unit_production)
         .add_systems(

--- a/server/src/map_config.rs
+++ b/server/src/map_config.rs
@@ -1,0 +1,209 @@
+use bevy::prelude::*;
+use bevy_replicon::prelude::*;
+use shared::components::{Host, TurnPhase, TurnState};
+use shared::events::SetMapConfig;
+use shared::map_settings::MapSettings;
+
+use crate::players::PlayerMap;
+
+/// Stores the host's chosen map settings while in the lobby. The generator reads
+/// `MapSettings` at game start (see `map_gen::generate_map_on_start`), so updating
+/// the resource here is all that's needed for the next game to use these settings.
+///
+/// Only honored when (a) the sender is the host and (b) we're still in the Lobby
+/// phase — mirrors `handle_start_game`'s host + phase gate, but without the
+/// player-count / defeated / victorious checks (irrelevant to picking a map).
+pub fn handle_set_map_config(
+    trigger: On<FromClient<SetMapConfig>>,
+    player_map: Res<PlayerMap>,
+    hosts: Query<(), With<Host>>,
+    turn_state: Query<&TurnState>,
+    mut map_settings: ResMut<MapSettings>,
+) {
+    let Ok(state) = turn_state.single() else {
+        return;
+    };
+    if state.phase != TurnPhase::Lobby {
+        return;
+    }
+
+    let client_entity = match trigger.client_id {
+        ClientId::Client(e) => e,
+        ClientId::Server => return,
+    };
+    let Some(&player_entity) = player_map.client_to_player.get(&client_entity) else {
+        return;
+    };
+
+    if !hosts.contains(player_entity) {
+        println!("Rejected SetMapConfig: sender is not the host");
+        return;
+    }
+
+    *map_settings = trigger.message.0;
+    println!("Map settings updated by host: {:?}", *map_settings);
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::app::ScheduleRunnerPlugin;
+    use bevy::state::app::StatesPlugin;
+    use bevy_replicon::prelude::*;
+    use shared::components::{Host, Player, TurnPhase, TurnState};
+    use shared::map_settings::{MapSettings, MapSize};
+
+    use super::*;
+    use crate::players::PlayerMap;
+
+    /// Build a minimal app with the observer wired and a default `MapSettings`.
+    fn map_config_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins.set(ScheduleRunnerPlugin::run_once()),
+            StatesPlugin,
+            RepliconPlugins,
+        ));
+        app.init_resource::<PlayerMap>();
+        app.init_resource::<MapSettings>();
+        app.add_observer(handle_set_map_config);
+        app.update();
+        app
+    }
+
+    /// A non-default payload so "did the resource change?" is unambiguous.
+    fn sample_settings() -> MapSettings {
+        MapSettings {
+            size: MapSize::Large,
+            seed: Some(42),
+            hilliness: 0.5,
+            forest: 0.5,
+            water: 0.5,
+        }
+    }
+
+    #[test]
+    fn handle_set_map_config_host_in_lobby_updates_settings() {
+        let mut app = map_config_app();
+
+        let client = {
+            let world = app.world_mut();
+            world.spawn(TurnState {
+                phase: TurnPhase::Lobby,
+                turn_number: 0,
+            });
+            let host_player = world
+                .spawn((
+                    Player {
+                        color_index: 0,
+                        gold: 0,
+                    },
+                    Host,
+                ))
+                .id();
+            let client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(client, host_player);
+            client
+        };
+
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(client),
+            message: SetMapConfig(sample_settings()),
+        });
+        app.world_mut().flush();
+
+        assert_eq!(
+            *app.world().resource::<MapSettings>(),
+            sample_settings(),
+            "host SetMapConfig in Lobby must update the MapSettings resource"
+        );
+    }
+
+    #[test]
+    fn handle_set_map_config_rejects_non_host_sender() {
+        let mut app = map_config_app();
+
+        let non_host_client = {
+            let world = app.world_mut();
+            world.spawn(TurnState {
+                phase: TurnPhase::Lobby,
+                turn_number: 0,
+            });
+            // Host exists, but the message comes from a different (non-host) player.
+            world.spawn((
+                Player {
+                    color_index: 0,
+                    gold: 0,
+                },
+                Host,
+            ));
+            let non_host_player = world
+                .spawn(Player {
+                    color_index: 1,
+                    gold: 0,
+                })
+                .id();
+            let non_host_client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(non_host_client, non_host_player);
+            non_host_client
+        };
+
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(non_host_client),
+            message: SetMapConfig(sample_settings()),
+        });
+        app.world_mut().flush();
+
+        assert_eq!(
+            *app.world().resource::<MapSettings>(),
+            MapSettings::default(),
+            "non-host SetMapConfig must be rejected; settings stay at default"
+        );
+    }
+
+    #[test]
+    fn handle_set_map_config_rejects_outside_lobby() {
+        let mut app = map_config_app();
+
+        let client = {
+            let world = app.world_mut();
+            // Game already started — phase is Accepting, not Lobby.
+            world.spawn(TurnState {
+                phase: TurnPhase::Accepting,
+                turn_number: 1,
+            });
+            let host_player = world
+                .spawn((
+                    Player {
+                        color_index: 0,
+                        gold: 0,
+                    },
+                    Host,
+                ))
+                .id();
+            let client = world.spawn_empty().id();
+            world
+                .resource_mut::<PlayerMap>()
+                .client_to_player
+                .insert(client, host_player);
+            client
+        };
+
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(client),
+            message: SetMapConfig(sample_settings()),
+        });
+        app.world_mut().flush();
+
+        assert_eq!(
+            *app.world().resource::<MapSettings>(),
+            MapSettings::default(),
+            "SetMapConfig outside Lobby must be rejected; settings stay at default"
+        );
+    }
+}

--- a/shared/src/events.rs
+++ b/shared/src/events.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::hex::HexPosition;
+use crate::map_settings::MapSettings;
 use crate::production::ProductionRecipeId;
 use crate::unit_definition::UnitVerb;
 
@@ -50,6 +51,12 @@ pub struct FinishTurn;
 /// Client-to-server event: host requests the game to start (Lobby → Accepting).
 #[derive(Event, Serialize, Deserialize, Clone, Debug)]
 pub struct StartGame;
+
+/// Client-to-server event: host updates the map-generation settings while in the
+/// lobby. The server stores the payload in its `MapSettings` resource, which the
+/// generator reads at game start. Only honored from the host during the Lobby phase.
+#[derive(Event, Serialize, Deserialize, Clone, Debug)]
+pub struct SetMapConfig(pub MapSettings);
 
 /// Single client-to-server event covering city-level actions.
 /// `city` is mapped by replicon between client-side and server-side Entity ids.

--- a/shared/src/plugin.rs
+++ b/shared/src/plugin.rs
@@ -41,6 +41,7 @@ impl Plugin for SharedPlugin {
             .add_mapped_client_event::<CityActionEvent>(Channel::Ordered)
             .add_client_event::<FinishTurn>(Channel::Ordered)
             .add_client_event::<StartGame>(Channel::Ordered)
+            .add_client_event::<SetMapConfig>(Channel::Ordered)
             .add_mapped_server_event::<YourPlayer>(Channel::Ordered)
             .add_systems(
                 Startup,


### PR DESCRIPTION
## Lobby map-config UI (terrain wave, PR 1 of 4)

Lets the host shape the next game's map from the lobby. Builds on the
`feat/terrain-foundation` `MapSettings` resource and the server's
game-start generator, so updating the server's `MapSettings` in the lobby
is all that's needed for the next game to use it.

### What's here
- **Shared:** new `SetMapConfig(MapSettings)` client→server event, registered
  in `SharedPlugin` as an ordered client event (mirrors `StartGame`).
- **Server:** `handle_set_map_config` observer writes the payload into the
  `MapSettings` resource, but only when the sender is the host and the phase is
  `Lobby` (same authority gate as `handle_start_game`, minus the player-count /
  defeated / victorious checks that don't apply to picking a map). Wired into the
  server app.
- **Client:** host-only Map Settings section in the lobby panel — Small/Medium/
  Large size buttons and Low/Med/High steppers for hilliness, forest, and water
  (discrete buttons, since bevy_ui has no slider widget). Clicks update a
  client-side `MapSettings` resource and push it via `SetMapConfig`. A dedicated
  `update_map_config_ui` system handles visibility + selection highlighting,
  kept separate from `update_lobby_ui` to avoid colliding with its disjoint
  `&mut Node` queries.

### Notes / scope
- Seed is left at `None` (random each game) on purpose — bevy_ui has no
  text-entry widget, so a free-text seed field is out of scope here.
- Minor cosmetic: the default `water` weight (0.2) buckets to the "Low"
  highlight on first open since no button produces exactly 0.2; it self-corrects
  the moment the host clicks any water button. Display-only.
- The panel's visual/interaction check is left for post-merge (the client needs
  a window/GPU and can't run headless).

### Tests
Server-side unit tests for `handle_set_map_config`: host in Lobby updates
`MapSettings`, non-host rejected, non-Lobby rejected. `build` / `test` /
`clippy` / `fmt --check` all green across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
