### PR TITLE
Follow-moves: queue a move onto a friendly-occupied tile (#24)

### DIFF
--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -324,14 +324,6 @@ pub fn handle_left_click(
             }
         }
         Some(InputSelection::Targeting { unit, verb }) => {
-            // clicking another owned unit always switches selection
-            if let Some(entity) = owned_unit_at(target) {
-                controller.selected_city = None;
-                next_ui_state.set(UiState::Input {
-                    selection: InputSelection::UnitSelected { unit: entity },
-                });
-                return;
-            }
             let Ok((_, u, _, pos)) = units.get(*unit) else {
                 next_ui_state.set(UiState::Input {
                     selection: InputSelection::Idle,
@@ -346,6 +338,12 @@ pub fn handle_left_click(
             };
             match verb {
                 TargetableVerb::Move => {
+                    // A click in Move mode commits a move to `target`, including onto a
+                    // tile a friendly currently occupies — that is how follow-moves,
+                    // swaps, and rotations are issued: the occupant may vacate this turn
+                    // (all moves resolve simultaneously), and the server rolls the move
+                    // back if the tile isn't actually freed. Reselecting a different
+                    // unit happens from the selected state, before entering Move mode.
                     let city_at_target = cities.iter().find(|(city_pos, _)| **city_pos == target);
                     let valid_city_target = city_at_target.is_none_or(|(_, city_owner)| {
                         city_owner.entity == player_entity || def.attack_range == 1
@@ -372,6 +370,15 @@ pub fn handle_left_click(
                     }
                 }
                 TargetableVerb::Attack => {
+                    // Clicking one of your own units isn't an attack target — treat it
+                    // as switching the selection instead.
+                    if let Some(entity) = owned_unit_at(target) {
+                        controller.selected_city = None;
+                        next_ui_state.set(UiState::Input {
+                            selection: InputSelection::UnitSelected { unit: entity },
+                        });
+                        return;
+                    }
                     // attacker is at `pos`; enemies are units with a different owner_id at `target`
                     let enemy_here = units
                         .iter()

--- a/server/src/combat/algorithm.rs
+++ b/server/src/combat/algorithm.rs
@@ -7,14 +7,23 @@ use super::types::{CityCapture, CitySnapshot, CombatDeltas, ResolveAction, UnitS
 /// Pure combat resolver. Borrows snapshots so the wrapper can keep the Vec
 /// around for logging without cloning.
 ///
-/// The algorithm has three phases per loop iteration:
-/// (1) find a tile with 2+ live units (a conflict),
-/// (2) apply one round of all-vs-all simultaneous damage there,
-/// (3) either settle the tile (≤1 survivor) or rollback survivors to start_pos.
+/// Units are placed optimistically at their desired tile, then conflicts are
+/// drained per loop iteration:
+/// (1) find a contested tile (2+ live units);
+/// (2) if two of them share an owner the move *failed*, so roll the arriving
+///     unit(s) (start_pos != tile) back to start with no damage — friendlies
+///     never hit each other; otherwise apply one round of all-vs-all
+///     simultaneous damage;
+/// (3) settle the tile (≤1 survivor) or roll surviving combatants back to start.
 ///
-/// Iteration stops when no conflict remains. Termination is guaranteed by
-/// `start_pos` uniqueness (enforced by handle_unit_action's friendly-stack
-/// checks); the 256-iteration cap is a sanity guard.
+/// City assaults resolve after unit conflicts, then the whole thing re-runs to a
+/// fixpoint because a failed assault rolls its attacker back, which can re-create
+/// a same-owner conflict with a follower that moved into the vacated tile.
+///
+/// Termination: every position write moves a unit *toward* its start_pos, and a
+/// unit at its start is never advanced again, so each unit rolls back at most
+/// once. With unique start positions, rollbacks and combat settlements are each
+/// bounded by the unit count; the iteration cap is a generous sanity guard.
 pub fn resolve_movement_pure(
     units: &[UnitSnapshot],
     cities: &[CitySnapshot],
@@ -53,31 +62,75 @@ pub fn resolve_movement_pure(
         hps.insert(u.entity, u.hp);
     }
 
+    // Single fixpoint: drain unit conflicts one at a time; when none remain,
+    // resolve city assaults, and loop again only if an assault rolled an attacker
+    // back (which can re-create a same-owner conflict with a follower that moved
+    // into the vacated tile). `iter_count` is total iterations.
+    // Generous O(N) sanity cap; see the termination note in the doc-comment.
+    let iter_bound = 4 * units.len() as u32 + 16;
     let mut iter_count = 0_u32;
     loop {
         iter_count += 1;
-        assert!(iter_count < 256, "rollback chain failed to terminate");
+        assert!(
+            iter_count < iter_bound,
+            "rollback chain failed to terminate"
+        );
 
-        let Some((_tile, combatants)) = find_first_conflict(&positions, &deaths) else {
-            break;
-        };
-        let survivors = apply_combat_at_tile(&combatants, &by_entity, &mut hps, &mut deaths);
-        if survivors.len() > 1 {
-            rollback_to_start(&survivors, &by_entity, &mut positions);
+        if let Some((tile, combatants)) = next_conflict(&positions, &deaths) {
+            // Same-owner co-location is a failed move, not a battle: roll back the
+            // unit(s) that arrived here (start_pos != tile) and let the loop cascade
+            // backward along the chain. The resident (start_pos == tile) keeps the
+            // tile. Yielding before any damage is what stops friendlies from hitting
+            // each other, and re-resolves a mixed friendly+enemy tile as a clean
+            // melee once the friendly intruder steps off.
+            let same_owner_movers: Vec<Entity> = combatants
+                .iter()
+                .copied()
+                .filter(|&e| {
+                    by_entity[&e].start_pos != tile
+                        && combatants
+                            .iter()
+                            .any(|&o| o != e && by_entity[&o].owner == by_entity[&e].owner)
+                })
+                .collect();
+            if !same_owner_movers.is_empty() {
+                debug_assert!(
+                    combatants
+                        .iter()
+                        .filter(|&&e| by_entity[&e].start_pos == tile)
+                        .count()
+                        <= 1,
+                    "same-owner conflict must have at most one resident (in-degree / unique-start invariant)"
+                );
+                rollback_to_start(&same_owner_movers, &by_entity, &mut positions);
+                continue;
+            }
+
+            let survivors = apply_combat_at_tile(&combatants, &by_entity, &mut hps, &mut deaths);
+            if survivors.len() > 1 {
+                rollback_to_start(&survivors, &by_entity, &mut positions);
+            }
+            // 0 or 1 alive: tile is settled; sole survivor (if any) stays at the conflict tile.
+            continue;
         }
-        // 0 or 1 alive: tile is already settled; sole survivor (if any) stays at the conflict tile.
-    }
 
-    resolve_city_melee(
-        units,
-        cities,
-        &mut positions,
-        &deaths,
-        &mut city_hps,
-        &mut city_owners,
-        city_capture_hp,
-        &mut city_captures,
-    );
+        // No unit conflicts remain. A failed city assault rolls its attacker back
+        // onto its start tile, which can re-create a same-owner conflict with a
+        // follower — so loop again to drain it; otherwise we are done.
+        let city_rolled_back = resolve_city_melee(
+            units,
+            cities,
+            &mut positions,
+            &deaths,
+            &mut city_hps,
+            &mut city_owners,
+            city_capture_hp,
+            &mut city_captures,
+        );
+        if !city_rolled_back {
+            break;
+        }
+    }
 
     let hp_changes: HashMap<Entity, i32> = hps
         .iter()
@@ -105,6 +158,9 @@ pub fn resolve_movement_pure(
     }
 }
 
+/// Returns true if it rolled any attacker back to its start (a failed assault),
+/// signalling the caller to re-drain unit conflicts — the rolled-back attacker
+/// may now share a tile with a follower that moved into the tile it vacated.
 #[allow(clippy::too_many_arguments)]
 fn resolve_city_melee(
     units: &[UnitSnapshot],
@@ -115,7 +171,8 @@ fn resolve_city_melee(
     city_owners: &mut HashMap<Entity, Entity>,
     city_capture_hp: u32,
     city_captures: &mut Vec<CityCapture>,
-) {
+) -> bool {
+    let mut rolled_back = false;
     let mut attackers: Vec<_> = units
         .iter()
         .filter(|unit| unit.hp > 0)
@@ -155,13 +212,21 @@ fn resolve_city_melee(
             });
         } else {
             positions.insert(unit.entity, unit.start_pos);
+            rolled_back = true;
         }
     }
+    rolled_back
 }
 
-/// Find the first tile that has 2+ live units (excluding already-dead entities).
-/// Returns the tile and its combatants, or None when the world is conflict-free.
-fn find_first_conflict(
+/// Find the next contested tile (2+ live units, excluding already-dead
+/// entities), chosen deterministically as the smallest tile by (q, r). HashMap
+/// iteration order is unspecified, so picking the min tile makes turn resolution
+/// reproducible run-to-run (stable tests and replays). The combat outcome itself
+/// is order-independent — all-vs-all damage is summed before it is applied, and
+/// rollbacks/yields are keyed by entity — so the combatants list order does not
+/// matter and is returned as-is. Returns the tile and its combatants, or None
+/// when no tile has 2+ live units.
+fn next_conflict(
     positions: &HashMap<Entity, HexPosition>,
     deaths: &HashSet<Entity>,
 ) -> Option<(HexPosition, Vec<Entity>)> {
@@ -172,7 +237,10 @@ fn find_first_conflict(
         }
         by_tile.entry(p).or_default().push(e);
     }
-    by_tile.into_iter().find(|(_, list)| list.len() >= 2)
+    by_tile
+        .into_iter()
+        .filter(|(_, list)| list.len() >= 2)
+        .min_by_key(|(tile, _)| (tile.q, tile.r))
 }
 
 /// One round of all-vs-all simultaneous damage among `combatants` on the same tile.
@@ -247,9 +315,10 @@ mod tests {
 
     #[test]
     fn two_way_conflict_both_alive_rolls_back() {
-        let (_world, entities) = fake_entities(2);
-        let p1 = Entity::PLACEHOLDER;
-        let p2 = Entity::PLACEHOLDER;
+        let (_world, entities) = fake_entities(4);
+        // Distinct owners → enemy combat, not a friendly failed move.
+        let p1 = entities[2];
+        let p2 = entities[3];
         // A at (0,0) moves to (1,0); B at (1,0) is stationary.
         let snapshot = vec![
             UnitSnapshot {
@@ -293,15 +362,17 @@ mod tests {
 
     #[test]
     fn two_way_conflict_one_survivor_takes_tile() {
-        let (_world, entities) = fake_entities(2);
-        let p = Entity::PLACEHOLDER;
+        let (_world, entities) = fake_entities(4);
+        // Distinct owners → enemy combat, not a friendly failed move.
+        let p1 = entities[2];
+        let p2 = entities[3];
         // A is much stronger and B is on its last legs.
         // A: 10/10 HP, 8 atk. B: 4/4 HP, 2 atk.
         // After exchange: A takes 2 → 8 HP (alive). B takes 8 → 0 HP (dead).
         let snapshot = vec![
             UnitSnapshot {
                 entity: entities[0],
-                owner: p,
+                owner: p1,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 8,
@@ -311,7 +382,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[1],
-                owner: p,
+                owner: p2,
                 hp: 4,
                 max_hp: 4,
                 attack_damage: 2,
@@ -336,13 +407,15 @@ mod tests {
 
     #[test]
     fn two_way_conflict_both_die_tile_empty() {
-        let (_world, entities) = fake_entities(2);
-        let p = Entity::PLACEHOLDER;
+        let (_world, entities) = fake_entities(4);
+        // Distinct owners → enemy combat, not a friendly failed move.
+        let p1 = entities[2];
+        let p2 = entities[3];
         // Each does 10 damage, both have 8 HP.
         let snapshot = vec![
             UnitSnapshot {
                 entity: entities[0],
-                owner: p,
+                owner: p1,
                 hp: 8,
                 max_hp: 8,
                 attack_damage: 10,
@@ -352,7 +425,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[1],
-                owner: p,
+                owner: p2,
                 hp: 8,
                 max_hp: 8,
                 attack_damage: 10,
@@ -370,14 +443,17 @@ mod tests {
 
     #[test]
     fn three_way_conflict_each_takes_sum_of_others() {
-        let (_world, entities) = fake_entities(3);
-        let p = Entity::PLACEHOLDER;
+        let (_world, entities) = fake_entities(6);
+        // Three distinct owners → full all-vs-all enemy combat.
+        let p1 = entities[3];
+        let p2 = entities[4];
+        let p3 = entities[5];
         // All three converge on (1, 0). attack_damage = 4 each.
         // Each takes 4 + 4 = 8 damage; HPs are 10, 12, 14 → 2, 4, 6 — all alive.
         let snapshot = vec![
             UnitSnapshot {
                 entity: entities[0],
-                owner: p,
+                owner: p1,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 4,
@@ -387,7 +463,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[1],
-                owner: p,
+                owner: p2,
                 hp: 12,
                 max_hp: 12,
                 attack_damage: 4,
@@ -397,7 +473,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[2],
-                owner: p,
+                owner: p3,
                 hp: 14,
                 max_hp: 14,
                 attack_damage: 4,
@@ -437,8 +513,12 @@ mod tests {
         // Iter 2: T1 conflict (A, C) → both -4 (A now at 6, C at 10).
         //         A→2 HP, C→6 HP. Survivors rollback. A→T1 (no-op), C→T3.
         // Final: A@T1 (2/10), B@T2 (6/10), C@T3 (6/10).
-        let (_world, entities) = fake_entities(3);
-        let p = Entity::PLACEHOLDER;
+        let (_world, entities) = fake_entities(6);
+        // Three distinct owners → each conflict is enemy combat (same cascade
+        // shape a friendly chain takes, but with damage).
+        let p1 = entities[3];
+        let p2 = entities[4];
+        let p3 = entities[5];
         let t1 = HexPosition::new(0, 0);
         let t2 = HexPosition::new(1, 0);
         let t3 = HexPosition::new(2, 0);
@@ -446,7 +526,7 @@ mod tests {
         let snapshot = vec![
             UnitSnapshot {
                 entity: entities[0],
-                owner: p,
+                owner: p1,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 4,
@@ -456,7 +536,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[1],
-                owner: p,
+                owner: p2,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 4,
@@ -466,7 +546,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[2],
-                owner: p,
+                owner: p3,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 4,
@@ -502,8 +582,10 @@ mod tests {
 
     #[test]
     fn move_into_enemy_misses_when_defender_vacated() {
-        let (_world, entities) = fake_entities(2);
-        let p = Entity::PLACEHOLDER;
+        let (_world, entities) = fake_entities(4);
+        // Distinct owners: A hopes to catch enemy B, but B vacates first.
+        let p1 = entities[2];
+        let p2 = entities[3];
         // A moves T1→T2 hoping to hit B; B moves T2→T3, vacating T2.
         let t1 = HexPosition::new(0, 0);
         let t2 = HexPosition::new(1, 0);
@@ -511,7 +593,7 @@ mod tests {
         let snapshot = vec![
             UnitSnapshot {
                 entity: entities[0],
-                owner: p,
+                owner: p1,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 4,
@@ -521,7 +603,7 @@ mod tests {
             },
             UnitSnapshot {
                 entity: entities[1],
-                owner: p,
+                owner: p2,
                 hp: 10,
                 max_hp: 10,
                 attack_damage: 4,
@@ -670,5 +752,246 @@ mod tests {
         assert_eq!(deltas.final_positions.get(&entities[0]), Some(&city_pos));
         assert!(deltas.city_hp_changes.is_empty());
         assert!(deltas.city_captures.is_empty());
+    }
+
+    /// Standard warrior snapshot (hp 10, atk 4, range 1) for follow-move tests.
+    fn warrior(
+        entity: Entity,
+        owner: Entity,
+        start: HexPosition,
+        action: ResolveAction,
+    ) -> UnitSnapshot {
+        UnitSnapshot {
+            entity,
+            owner,
+            hp: 10,
+            max_hp: 10,
+            attack_damage: 4,
+            attack_range: 1,
+            start_pos: start,
+            action,
+        }
+    }
+
+    #[test]
+    fn happy_chain_follows_into_vacated_tile() {
+        let (_world, e) = fake_entities(3);
+        let p = e[2];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let t3 = HexPosition::new(2, 0);
+        // A:T1→T2 follows B:T2→T3; T3 is empty.
+        let snapshot = vec![
+            warrior(e[0], p, t1, ResolveAction::MoveTo(t2)),
+            warrior(e[1], p, t2, ResolveAction::MoveTo(t3)),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        assert_eq!(deltas.final_positions.get(&e[0]), Some(&t2));
+        assert_eq!(deltas.final_positions.get(&e[1]), Some(&t3));
+        assert!(deltas.hp_changes.is_empty(), "friendly follow → no combat");
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn three_cycle_rotation_resolves_without_damage() {
+        let (_world, e) = fake_entities(4);
+        let p = e[3];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let t3 = HexPosition::new(2, 0);
+        // A→B→C→A rotation; every destination is vacated simultaneously.
+        let snapshot = vec![
+            warrior(e[0], p, t1, ResolveAction::MoveTo(t2)),
+            warrior(e[1], p, t2, ResolveAction::MoveTo(t3)),
+            warrior(e[2], p, t3, ResolveAction::MoveTo(t1)),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        assert_eq!(deltas.final_positions.get(&e[0]), Some(&t2));
+        assert_eq!(deltas.final_positions.get(&e[1]), Some(&t3));
+        assert_eq!(deltas.final_positions.get(&e[2]), Some(&t1));
+        assert!(deltas.hp_changes.is_empty(), "rotation → no combat");
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn two_unit_swap_resolves_without_damage() {
+        let (_world, e) = fake_entities(3);
+        let p = e[2];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let snapshot = vec![
+            warrior(e[0], p, t1, ResolveAction::MoveTo(t2)),
+            warrior(e[1], p, t2, ResolveAction::MoveTo(t1)),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        assert_eq!(deltas.final_positions.get(&e[0]), Some(&t2));
+        assert_eq!(deltas.final_positions.get(&e[1]), Some(&t1));
+        assert!(deltas.hp_changes.is_empty(), "swap → no combat");
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn stationary_friendly_occupant_rolls_back_mover_without_damage() {
+        // The core new case: B doesn't actually vacate, so A's follow fails — and
+        // friendlies must NOT damage each other (the old resolver dealt 4 to each).
+        let (_world, e) = fake_entities(3);
+        let p = e[2];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let snapshot = vec![
+            warrior(e[0], p, t1, ResolveAction::MoveTo(t2)),
+            warrior(e[1], p, t2, ResolveAction::Stationary),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        assert_eq!(deltas.final_positions.get(&e[0]), Some(&t1), "mover yields");
+        assert_eq!(
+            deltas.final_positions.get(&e[1]),
+            Some(&t2),
+            "resident stays"
+        );
+        assert!(deltas.hp_changes.is_empty(), "friendlies must not fight");
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn friendly_chain_blocked_by_stationary_tail_cascades_back() {
+        // A→B→C but C is stationary; the failure cascades backward: B yields, then A.
+        let (_world, e) = fake_entities(4);
+        let p = e[3];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let t3 = HexPosition::new(2, 0);
+        let snapshot = vec![
+            warrior(e[0], p, t1, ResolveAction::MoveTo(t2)),
+            warrior(e[1], p, t2, ResolveAction::MoveTo(t3)),
+            warrior(e[2], p, t3, ResolveAction::Stationary),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        assert_eq!(deltas.final_positions.get(&e[0]), Some(&t1));
+        assert_eq!(deltas.final_positions.get(&e[1]), Some(&t2));
+        assert_eq!(deltas.final_positions.get(&e[2]), Some(&t3));
+        assert!(
+            deltas.hp_changes.is_empty(),
+            "no friendly fire in a stalled chain"
+        );
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn mixed_tile_friendly_yields_before_enemy_combat() {
+        // T2 ends up with friendly resident R, friendly follower F, and enemy E.
+        // F must yield first so R↔E resolve as a clean melee — no friendly fire.
+        let (_world, e) = fake_entities(5);
+        let p = e[3];
+        let q = e[4];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let te = HexPosition::new(1, 1);
+        let (r, f, enemy) = (e[0], e[1], e[2]);
+        let snapshot = vec![
+            warrior(r, p, t2, ResolveAction::Stationary),
+            warrior(f, p, t1, ResolveAction::MoveTo(t2)),
+            warrior(enemy, q, te, ResolveAction::MoveTo(t2)),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        // Follower bounced home, untouched.
+        assert_eq!(deltas.final_positions.get(&f), Some(&t1));
+        assert!(
+            !deltas.hp_changes.contains_key(&f),
+            "follower takes no friendly fire"
+        );
+        // Resident and enemy traded one round, both survived and rolled apart.
+        assert_eq!(deltas.final_positions.get(&r), Some(&t2));
+        assert_eq!(deltas.final_positions.get(&enemy), Some(&te));
+        assert_eq!(deltas.hp_changes.get(&r), Some(&-4));
+        assert_eq!(deltas.hp_changes.get(&enemy), Some(&-4));
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn combat_broken_cycle_unwinds_to_start() {
+        // Friendly 3-cycle A→B→C→A, but enemy E also rushes the tile C targets (T1).
+        // C draws its melee and rolls back, unzipping the whole cycle to start.
+        let (_world, e) = fake_entities(6);
+        let p = e[4];
+        let q = e[5];
+        let t1 = HexPosition::new(0, 0);
+        let t2 = HexPosition::new(1, 0);
+        let t3 = HexPosition::new(2, 0);
+        let te = HexPosition::new(0, 1);
+        let (a, b, c, enemy) = (e[0], e[1], e[2], e[3]);
+        let snapshot = vec![
+            warrior(a, p, t1, ResolveAction::MoveTo(t2)),
+            warrior(b, p, t2, ResolveAction::MoveTo(t3)),
+            warrior(c, p, t3, ResolveAction::MoveTo(t1)),
+            warrior(enemy, q, te, ResolveAction::MoveTo(t1)),
+        ];
+
+        let deltas = resolve_movement_pure(&snapshot, &[], 10);
+
+        // Whole cycle unwound to start; enemy bounced home.
+        assert_eq!(deltas.final_positions.get(&a), Some(&t1));
+        assert_eq!(deltas.final_positions.get(&b), Some(&t2));
+        assert_eq!(deltas.final_positions.get(&c), Some(&t3));
+        assert_eq!(deltas.final_positions.get(&enemy), Some(&te));
+        // Only C and E fought; A and B merely yielded.
+        assert_eq!(deltas.hp_changes.get(&c), Some(&-4));
+        assert_eq!(deltas.hp_changes.get(&enemy), Some(&-4));
+        assert!(!deltas.hp_changes.contains_key(&a));
+        assert!(!deltas.hp_changes.contains_key(&b));
+        assert!(deltas.deaths.is_empty());
+    }
+
+    #[test]
+    fn failed_city_assault_rolls_back_follower_no_double_stack() {
+        // Regression: H assaults an enemy city and fails; follower M moved into H's
+        // vacated tile. City-melee rollback must re-enter conflict resolution so M
+        // also yields — no two friendlies left stacked on one tile.
+        let (_world, e) = fake_entities(5);
+        let p = e[2];
+        let q = e[3];
+        let city = e[4];
+        let s_m = HexPosition::new(0, 0);
+        let s_h = HexPosition::new(1, 0);
+        let city_pos = HexPosition::new(2, 0);
+        let snapshot = vec![
+            warrior(e[0], p, s_h, ResolveAction::MoveTo(city_pos)), // H assaults city
+            warrior(e[1], p, s_m, ResolveAction::MoveTo(s_h)),      // M follows into H's tile
+        ];
+        let cities = vec![CitySnapshot {
+            entity: city,
+            owner: q,
+            hp: 20,
+            max_hp: 20,
+            pos: city_pos,
+        }];
+
+        let deltas = resolve_movement_pure(&snapshot, &cities, 10);
+
+        // Both rolled back to their own start — no shared tile.
+        assert_eq!(deltas.final_positions.get(&e[0]), Some(&s_h));
+        assert_eq!(deltas.final_positions.get(&e[1]), Some(&s_m));
+        assert_ne!(
+            deltas.final_positions.get(&e[0]),
+            deltas.final_positions.get(&e[1]),
+            "followers must not double-stack after a failed city assault"
+        );
+        // City damaged but held; no capture; no unit-vs-unit combat.
+        assert_eq!(deltas.city_hp_changes.get(&city), Some(&-4));
+        assert!(deltas.city_captures.is_empty());
+        assert!(deltas.hp_changes.is_empty());
+        assert!(deltas.deaths.is_empty());
     }
 }

--- a/server/src/combat/systems.rs
+++ b/server/src/combat/systems.rs
@@ -308,6 +308,85 @@ mod tests {
     }
 
     #[test]
+    fn resolve_movement_friendly_follow_chain_advances() {
+        // Drives the new follow-move behavior through the real ECS wrapper
+        // (snapshot → resolve → apply), not just the pure resolver: two friendly
+        // units in a column both advance one tile when the leader vacates.
+        let mut app = App::new();
+        app.add_systems(Update, super::resolve_movement);
+
+        let warrior_id = UnitTypeId(0);
+        let warrior_def = UnitDefinition {
+            hp: 10,
+            move_budget: 2,
+            attack_range: 1,
+            attack_damage: 4,
+            gold_upkeep: 1,
+            production_cost: 10,
+            build_targets: vec![],
+            terrain_cost: HashMap::new(),
+        };
+        let mut registry = UnitRegistry::default();
+        registry.name_to_id.insert("warrior".into(), warrior_id);
+        registry.definitions.insert(warrior_id, warrior_def);
+        app.insert_resource(registry);
+
+        // A:(0,0)→(1,0) follows B:(1,0)→(2,0), both owned by the same player.
+        let (a, b) = {
+            let world = app.world_mut();
+            let p = world
+                .spawn(Player {
+                    color_index: 0,
+                    gold: 0,
+                })
+                .id();
+            let a = world
+                .spawn((
+                    Unit {
+                        type_id: warrior_id,
+                    },
+                    HexPosition::new(0, 0),
+                    Owner(p),
+                    Health::full(10),
+                    MoveTo {
+                        pos: HexPosition::new(1, 0),
+                    },
+                ))
+                .id();
+            let b = world
+                .spawn((
+                    Unit {
+                        type_id: warrior_id,
+                    },
+                    HexPosition::new(1, 0),
+                    Owner(p),
+                    Health::full(10),
+                    MoveTo {
+                        pos: HexPosition::new(2, 0),
+                    },
+                ))
+                .id();
+            (a, b)
+        };
+
+        app.update();
+
+        // Both advanced; no friendly fire; markers consumed.
+        assert_eq!(
+            *app.world().get::<HexPosition>(a).unwrap(),
+            HexPosition::new(1, 0)
+        );
+        assert_eq!(
+            *app.world().get::<HexPosition>(b).unwrap(),
+            HexPosition::new(2, 0)
+        );
+        assert_eq!(app.world().get::<Health>(a).unwrap().current, 10);
+        assert_eq!(app.world().get::<Health>(b).unwrap().current, 10);
+        assert!(app.world().get::<MoveTo>(a).is_none());
+        assert!(app.world().get::<MoveTo>(b).is_none());
+    }
+
+    #[test]
     fn resolve_movement_two_way_stalemate_rolls_back() {
         let mut app = App::new();
         app.add_systems(Update, super::resolve_movement);

--- a/server/src/combat/types.rs
+++ b/server/src/combat/types.rs
@@ -12,15 +12,15 @@ use std::collections::{HashMap, HashSet};
 #[derive(Clone, Debug)]
 pub struct UnitSnapshot {
     pub entity: Entity,
-    // owner, max_hp, and attack_range are captured for future algorithm expansions
-    // (e.g. faction-aware combat, morale, extended-range melee) but not yet read.
-    #[allow(dead_code)]
+    // owner distinguishes friendly co-location (a failed move — the mover yields)
+    // from enemy co-location (combat) during resolution.
     pub owner: Entity,
     pub hp: i32,
+    // max_hp is captured for future algorithm expansions (e.g. morale, healing
+    // caps) but not yet read by the resolver.
     #[allow(dead_code)]
     pub max_hp: u32,
     pub attack_damage: u32,
-    #[allow(dead_code)]
     pub attack_range: u32,
     pub start_pos: HexPosition,
     pub action: ResolveAction,

--- a/server/src/turn.rs
+++ b/server/src/turn.rs
@@ -250,14 +250,10 @@ pub fn handle_unit_action(
                 println!("Rejected move: target not reachable");
                 return;
             }
-            // Reject if a friendly is currently standing on the target tile.
-            if units
-                .iter()
-                .any(|(p, o, _)| p == target && o.0 == *player_entity)
-            {
-                println!("Rejected move: friendly already on tile");
-                return;
-            }
+            // A friendly standing on the target tile is allowed: moves resolve
+            // simultaneously, so the occupant may vacate this turn (follow-moves,
+            // rotations, swaps). The resolver is the source of truth — if the tile
+            // isn't actually freed, it rolls this move back at turn end.
             if let Some((_, city_owner)) = cities.iter().find(|(p, _)| *p == target)
                 && city_owner.entity != *player_entity
                 && def.attack_range != 1
@@ -1023,7 +1019,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_unit_action_rejects_move_to_friendly_occupied_tile() {
+    fn test_handle_unit_action_allows_move_onto_friendly_occupied_tile() {
         use crate::players::PlayerMap;
         use bevy::app::ScheduleRunnerPlugin;
         use bevy::state::app::StatesPlugin;
@@ -1105,7 +1101,9 @@ mod tests {
             (client, player, mover, blocker)
         };
 
-        // Try to move mover onto blocker's tile.
+        // Move mover onto blocker's tile. Now accepted at submit: moves resolve
+        // simultaneously, so the blocker may vacate this turn. The resolver rolls
+        // the move back at turn end if the tile isn't actually freed.
         app.world_mut().trigger(FromClient {
             client_id: ClientId::Client(client),
             message: UnitActionEvent {
@@ -1117,10 +1115,10 @@ mod tests {
         });
         app.world_mut().flush();
 
-        // Move must be rejected: no MoveTo on the mover.
+        // Move must be accepted: MoveTo queued on the mover.
         assert!(
-            app.world().get::<MoveTo>(mover).is_none(),
-            "Move to friendly-occupied tile must be rejected"
+            app.world().get::<MoveTo>(mover).is_some(),
+            "Move onto a friendly-occupied tile must be accepted (resolver decides)"
         );
         let _ = (player, blocker);
     }


### PR DESCRIPTION
## Problem

A unit couldn't be ordered onto a hex one of its own units was standing on, so natural maneuvers were impossible in a single turn: advancing a column one step, following a unit into the space it vacates, or swapping two adjacent units. Because moves resolve simultaneously at turn end, a tile that looks occupied when the order is given is often free by the time movement happens.

Closes #24.

## Approach

**Server (resolver).** Movement resolution is now ownership-aware. A contested tile holding two units of the same owner is treated as a *failed move* rather than a battle: the unit that arrived rolls back to its start before any damage, and the loop cascades that backward along the chain. With the existing "two friendlies can't target the same tile" guard kept, the friendly move graph is a partial permutation, so chains, rotation cycles, and 2-unit swaps all resolve simultaneously for free; only the failure path needed new logic. Friendlies never damage each other, and a mixed friendly+enemy tile re-resolves as a clean melee once the friendly intruder steps off. Unit conflicts and city assaults now resolve in a single fixpoint so a failed assault can't leave a follower stacked on the attacker's tile, and conflict-tile selection is deterministic for reproducible resolution. The submit-time rejection of moving onto a friendly tile was removed (permissive); the resolver is the source of truth and rolls a move back if the tile isn't actually freed.

**Client (input).** Move-targeting mode now sends the order when you click a friendly-occupied tile — previously it intercepted the click as a reselection, so swaps/follows never reached the server. Reselecting a unit still works from the selected state, and clicking your own unit in Attack mode still switches selection. The move preview already highlights these tiles as valid, so the interaction is consistent.

## Testing

- Pure-resolver and ECS-wrapper unit tests cover happy chains, rotations, swaps, stationary-occupant rollback, multi-step cascades, mixed-owner tiles (no friendly fire), combat-broken cycles, and a city double-stack regression. Existing combat tests were migrated to distinct owners so they stay combat tests under the new ownership-aware branch.
- Verified manually in-game: swap, follow-chain, 3-cycle rotation, blocked-follow rollback, and unchanged enemy melee.
- `cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` are clean.

## Known follow-up (out of scope)

A pre-existing bug, surfaced during review: producing a unit onto a city tile already occupied by a friendly leaves two same-owner units stacked at turn start, which the resolver can't separate and would friendly-fire. The root cause is the lack of an occupancy check in unit production, not this branch. Recommended as a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)